### PR TITLE
Makes origin.TunnelMetrics public again

### DIFF
--- a/origin/metrics.go
+++ b/origin/metrics.go
@@ -27,7 +27,7 @@ type muxerMetrics struct {
 	outBoundRateMax  *prometheus.GaugeVec
 }
 
-type tunnelMetrics struct {
+type TunnelMetrics struct {
 	haConnections     prometheus.Gauge
 	totalRequests     prometheus.Counter
 	requestsPerTunnel *prometheus.CounterVec
@@ -229,7 +229,7 @@ func convertRTTMilliSec(t time.Duration) float64 {
 }
 
 // Metrics that can be collected without asking the edge
-func NewTunnelMetrics() *tunnelMetrics {
+func NewTunnelMetrics() *TunnelMetrics {
 	haConnections := prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "ha_connections",
@@ -305,7 +305,7 @@ func NewTunnelMetrics() *tunnelMetrics {
 	)
 	prometheus.MustRegister(serverLocations)
 
-	return &tunnelMetrics{
+	return &TunnelMetrics{
 		haConnections:                  haConnections,
 		totalRequests:                  totalRequests,
 		requestsPerTunnel:              requestsPerTunnel,
@@ -322,19 +322,19 @@ func NewTunnelMetrics() *tunnelMetrics {
 	}
 }
 
-func (t *tunnelMetrics) incrementHaConnections() {
+func (t *TunnelMetrics) incrementHaConnections() {
 	t.haConnections.Inc()
 }
 
-func (t *tunnelMetrics) decrementHaConnections() {
+func (t *TunnelMetrics) decrementHaConnections() {
 	t.haConnections.Dec()
 }
 
-func (t *tunnelMetrics) updateMuxerMetrics(connectionID string, metrics *h2mux.MuxerMetrics) {
+func (t *TunnelMetrics) updateMuxerMetrics(connectionID string, metrics *h2mux.MuxerMetrics) {
 	t.muxerMetrics.update(connectionID, metrics)
 }
 
-func (t *tunnelMetrics) incrementRequests(connectionID string) {
+func (t *TunnelMetrics) incrementRequests(connectionID string) {
 	t.concurrentRequestsLock.Lock()
 	var concurrentRequests uint64
 	var ok bool
@@ -356,7 +356,7 @@ func (t *tunnelMetrics) incrementRequests(connectionID string) {
 	t.concurrentRequestsPerTunnel.WithLabelValues(connectionID).Inc()
 }
 
-func (t *tunnelMetrics) decrementConcurrentRequests(connectionID string) {
+func (t *TunnelMetrics) decrementConcurrentRequests(connectionID string) {
 	t.concurrentRequestsLock.Lock()
 	if _, ok := t.concurrentRequests[connectionID]; ok {
 		t.concurrentRequests[connectionID] -= 1
@@ -368,13 +368,13 @@ func (t *tunnelMetrics) decrementConcurrentRequests(connectionID string) {
 	t.concurrentRequestsPerTunnel.WithLabelValues(connectionID).Dec()
 }
 
-func (t *tunnelMetrics) incrementResponses(connectionID, code string) {
+func (t *TunnelMetrics) incrementResponses(connectionID, code string) {
 	t.responseByCode.WithLabelValues(code).Inc()
 	t.responseCodePerTunnel.WithLabelValues(connectionID, code).Inc()
 
 }
 
-func (t *tunnelMetrics) registerServerLocation(connectionID, loc string) {
+func (t *TunnelMetrics) registerServerLocation(connectionID, loc string) {
 	t.locationLock.Lock()
 	defer t.locationLock.Unlock()
 	if oldLoc, ok := t.oldServerLocations[connectionID]; ok && oldLoc == loc {

--- a/origin/tunnel.go
+++ b/origin/tunnel.go
@@ -53,7 +53,7 @@ type TunnelConfig struct {
 	Tags              []tunnelpogs.Tag
 	HAConnections     int
 	HTTPTransport     http.RoundTripper
-	Metrics           *tunnelMetrics
+	Metrics           *TunnelMetrics
 	MetricsUpdateFreq time.Duration
 	ProtocolLogger    *logrus.Logger
 	Logger            *logrus.Logger
@@ -335,7 +335,7 @@ func UnregisterTunnel(muxer *h2mux.Muxer, gracePeriod time.Duration) error {
 func LogServerInfo(logger *logrus.Entry,
 	promise tunnelrpc.ServerInfo_Promise,
 	connectionID uint8,
-	metrics *tunnelMetrics,
+	metrics *TunnelMetrics,
 ) {
 	serverInfoMessage, err := promise.Struct()
 	if err != nil {
@@ -398,7 +398,7 @@ type TunnelHandler struct {
 	httpClient http.RoundTripper
 	tlsConfig  *tls.Config
 	tags       []tunnelpogs.Tag
-	metrics    *tunnelMetrics
+	metrics    *TunnelMetrics
 	// connectionID is only used by metrics, and prometheus requires labels to be string
 	connectionID string
 }


### PR DESCRIPTION
Test code must avoid the prometheus static initialization, and
can do this by creating a dummy TunnelMetrics object, provided
it is public.