### PR TITLE
HTTP timeout set to wrong value.

### DIFF
--- a/tunneldns/https_upstream.go
+++ b/tunneldns/https_upstream.go
@@ -43,7 +43,7 @@ func NewUpstreamHTTPS(endpoint string) (Upstream, error) {
 	http2.ConfigureTransport(transport)
 
 	client := &http.Client{
-		Timeout:   time.Second * defaultTimeout,
+		Timeout:   defaultTimeout,
 		Transport: transport,
 	}
 


### PR DESCRIPTION
Because the defaultTimeout is defined as a constant you do not need to multiply it by time.Second again otherwise you end up with some stupid timeout as seen here. https://play.golang.org/p/Dl7rU_n_8Ej