### PR TITLE
Metrics labels

### DIFF
--- a/cmd/cloudflared/main.go
+++ b/cmd/cloudflared/main.go
@@ -482,10 +482,11 @@ func startServer(c *cli.Context, shutdownC, graceShutdownC chan struct{}) error 
 		return err
 	}
 
+	metricsLabels := map[string]string{"application": "cloudflared"}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		errC <- origin.StartTunnelDaemon(tunnelConfig, graceShutdownC, connectedSignal)
+		errC <- origin.StartTunnelDaemon(tunnelConfig, graceShutdownC, connectedSignal, metricsLabels)
 	}()
 
 	return waitToShutdown(&wg, errC, shutdownC, graceShutdownC, c.Duration("grace-period"))

--- a/origin/metrics.go
+++ b/origin/metrics.go
@@ -54,7 +54,7 @@ type TunnelMetrics struct {
 func newMuxerMetrics() *muxerMetrics {
 	rtt := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "rtt",
+			Name: "argotunnel_rtt",
 			Help: "Round-trip time in millisecond",
 		},
 		[]string{"connection_id"},
@@ -63,7 +63,7 @@ func newMuxerMetrics() *muxerMetrics {
 
 	rttMin := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "rtt_min",
+			Name: "argotunnel_rtt_min",
 			Help: "Shortest round-trip time in millisecond",
 		},
 		[]string{"connection_id"},
@@ -72,7 +72,7 @@ func newMuxerMetrics() *muxerMetrics {
 
 	rttMax := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "rtt_max",
+			Name: "argotunnel_rtt_max",
 			Help: "Longest round-trip time in millisecond",
 		},
 		[]string{"connection_id"},
@@ -81,7 +81,7 @@ func newMuxerMetrics() *muxerMetrics {
 
 	receiveWindowAve := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "receive_window_ave",
+			Name: "argotunnel_receive_window_ave",
 			Help: "Average receive window size in bytes",
 		},
 		[]string{"connection_id"},
@@ -90,7 +90,7 @@ func newMuxerMetrics() *muxerMetrics {
 
 	sendWindowAve := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "send_window_ave",
+			Name: "argotunnel_send_window_ave",
 			Help: "Average send window size in bytes",
 		},
 		[]string{"connection_id"},
@@ -99,7 +99,7 @@ func newMuxerMetrics() *muxerMetrics {
 
 	receiveWindowMin := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "receive_window_min",
+			Name: "argotunnel_receive_window_min",
 			Help: "Smallest receive window size in bytes",
 		},
 		[]string{"connection_id"},
@@ -108,7 +108,7 @@ func newMuxerMetrics() *muxerMetrics {
 
 	receiveWindowMax := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "receive_window_max",
+			Name: "argotunnel_receive_window_max",
 			Help: "Largest receive window size in bytes",
 		},
 		[]string{"connection_id"},
@@ -117,7 +117,7 @@ func newMuxerMetrics() *muxerMetrics {
 
 	sendWindowMin := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "send_window_min",
+			Name: "argotunnel_send_window_min",
 			Help: "Smallest send window size in bytes",
 		},
 		[]string{"connection_id"},
@@ -126,7 +126,7 @@ func newMuxerMetrics() *muxerMetrics {
 
 	sendWindowMax := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "send_window_max",
+			Name: "argotunnel_send_window_max",
 			Help: "Largest send window size in bytes",
 		},
 		[]string{"connection_id"},
@@ -135,7 +135,7 @@ func newMuxerMetrics() *muxerMetrics {
 
 	inBoundRateCurr := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "inbound_bytes_per_sec_curr",
+			Name: "argotunnel_inbound_bytes_per_sec_curr",
 			Help: "Current inbounding bytes per second, 0 if there is no incoming connection",
 		},
 		[]string{"connection_id"},
@@ -144,7 +144,7 @@ func newMuxerMetrics() *muxerMetrics {
 
 	inBoundRateMin := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "inbound_bytes_per_sec_min",
+			Name: "argotunnel_inbound_bytes_per_sec_min",
 			Help: "Minimum non-zero inbounding bytes per second",
 		},
 		[]string{"connection_id"},
@@ -153,7 +153,7 @@ func newMuxerMetrics() *muxerMetrics {
 
 	inBoundRateMax := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "inbound_bytes_per_sec_max",
+			Name: "argotunnel_inbound_bytes_per_sec_max",
 			Help: "Maximum inbounding bytes per second",
 		},
 		[]string{"connection_id"},
@@ -162,7 +162,7 @@ func newMuxerMetrics() *muxerMetrics {
 
 	outBoundRateCurr := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "outbound_bytes_per_sec_curr",
+			Name: "argotunnel_outbound_bytes_per_sec_curr",
 			Help: "Current outbounding bytes per second, 0 if there is no outgoing traffic",
 		},
 		[]string{"connection_id"},
@@ -171,7 +171,7 @@ func newMuxerMetrics() *muxerMetrics {
 
 	outBoundRateMin := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "outbound_bytes_per_sec_min",
+			Name: "argotunnel_outbound_bytes_per_sec_min",
 			Help: "Minimum non-zero outbounding bytes per second",
 		},
 		[]string{"connection_id"},
@@ -180,7 +180,7 @@ func newMuxerMetrics() *muxerMetrics {
 
 	outBoundRateMax := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "outbound_bytes_per_sec_max",
+			Name: "argotunnel_outbound_bytes_per_sec_max",
 			Help: "Maximum outbounding bytes per second",
 		},
 		[]string{"connection_id"},
@@ -232,21 +232,21 @@ func convertRTTMilliSec(t time.Duration) float64 {
 func NewTunnelMetrics() *TunnelMetrics {
 	haConnections := prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "ha_connections",
+			Name: "argotunnel_ha_connections",
 			Help: "Number of active ha connections",
 		})
 	prometheus.MustRegister(haConnections)
 
 	totalRequests := prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "total_requests",
+			Name: "argotunnel_total_requests",
 			Help: "Amount of requests proxied through all the tunnels",
 		})
 	prometheus.MustRegister(totalRequests)
 
 	requestsPerTunnel := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "requests_per_tunnel",
+			Name: "argotunnel_requests_per_tunnel",
 			Help: "Amount of requests proxied through each tunnel",
 		},
 		[]string{"connection_id"},
@@ -255,7 +255,7 @@ func NewTunnelMetrics() *TunnelMetrics {
 
 	concurrentRequestsPerTunnel := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "concurrent_requests_per_tunnel",
+			Name: "argotunnel_concurrent_requests_per_tunnel",
 			Help: "Concurrent requests proxied through each tunnel",
 		},
 		[]string{"connection_id"},
@@ -264,7 +264,7 @@ func NewTunnelMetrics() *TunnelMetrics {
 
 	maxConcurrentRequestsPerTunnel := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "max_concurrent_requests_per_tunnel",
+			Name: "argotunnel_max_concurrent_requests_per_tunnel",
 			Help: "Largest number of concurrent requests proxied through each tunnel so far",
 		},
 		[]string{"connection_id"},
@@ -273,14 +273,14 @@ func NewTunnelMetrics() *TunnelMetrics {
 
 	timerRetries := prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "timer_retries",
+			Name: "argotunnel_timer_retries",
 			Help: "Unacknowledged heart beats count",
 		})
 	prometheus.MustRegister(timerRetries)
 
 	responseByCode := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "response_by_code",
+			Name: "argotunnel_response_by_code",
 			Help: "Count of responses by HTTP status code",
 		},
 		[]string{"status_code"},
@@ -289,7 +289,7 @@ func NewTunnelMetrics() *TunnelMetrics {
 
 	responseCodePerTunnel := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "response_code_per_tunnel",
+			Name: "argotunnel_response_code_per_tunnel",
 			Help: "Count of responses by HTTP status code fore each tunnel",
 		},
 		[]string{"connection_id", "status_code"},
@@ -298,7 +298,7 @@ func NewTunnelMetrics() *TunnelMetrics {
 
 	serverLocations := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "server_locations",
+			Name: "argotunnel_server_locations",
 			Help: "Where each tunnel is connected to. 1 means current location, 0 means previous locations.",
 		},
 		[]string{"connection_id", "location"},

--- a/origin/metrics.go
+++ b/origin/metrics.go
@@ -398,3 +398,15 @@ func (t *TunnelMetrics) registerServerLocation(metricLabelValues []string, loc s
 	t.serverLocations.WithLabelValues(labelValues...).Inc()
 	t.oldServerLocations[hashKey] = loc
 }
+
+// SetServerLocation is called by the tunnelHandler when the tunnel opens
+func (t *TunnelMetrics) SetServerLocation(metricLabelValues []string, loc string) {
+	labelValues := append(metricLabelValues, loc)
+	t.serverLocations.WithLabelValues(labelValues...).Set(1)
+}
+
+// UnsetServerLocation is called by the tunnelHandler when the tunnel closes, or at least is known to be closed
+func (t *TunnelMetrics) UnsetServerLocation(metricLabelValues []string, loc string) {
+	labelValues := append(metricLabelValues, loc)
+	t.serverLocations.WithLabelValues(labelValues...).Set(0)
+}

--- a/origin/metrics.go
+++ b/origin/metrics.go
@@ -31,8 +31,8 @@ type muxerMetrics struct {
 
 type TunnelMetrics struct {
 	haConnections prometheus.Gauge
-	totalRequests prometheus.Counter
-	requests      *prometheus.CounterVec
+
+	requests *prometheus.CounterVec
 	// concurrentRequestsLock is a mutex for concurrentRequests and maxConcurrentRequests
 	concurrentRequestsLock      sync.Mutex
 	concurrentRequestsPerTunnel *prometheus.GaugeVec
@@ -43,7 +43,7 @@ type TunnelMetrics struct {
 	maxConcurrentRequests map[uint64]uint64
 	timerRetries          prometheus.Gauge
 
-	reponses        *prometheus.CounterVec
+	responses       *prometheus.CounterVec
 	serverLocations *prometheus.GaugeVec
 	// locationLock is a mutex for oldServerLocations
 	locationLock sync.Mutex
@@ -53,13 +53,13 @@ type TunnelMetrics struct {
 	muxerMetrics *muxerMetrics
 }
 
-func newMuxerMetrics() *muxerMetrics {
+func newMuxerMetrics(baseMetricsLabels []string) *muxerMetrics {
 	rtt := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "argotunnel_rtt",
 			Help: "Round-trip time in millisecond",
 		},
-		[]string{"connection_id"},
+		append(baseMetricsLabels, "connection_id"),
 	)
 	prometheus.MustRegister(rtt)
 
@@ -68,7 +68,7 @@ func newMuxerMetrics() *muxerMetrics {
 			Name: "argotunnel_rtt_min",
 			Help: "Shortest round-trip time in millisecond",
 		},
-		[]string{"connection_id"},
+		append(baseMetricsLabels, "connection_id"),
 	)
 	prometheus.MustRegister(rttMin)
 
@@ -77,7 +77,7 @@ func newMuxerMetrics() *muxerMetrics {
 			Name: "argotunnel_rtt_max",
 			Help: "Longest round-trip time in millisecond",
 		},
-		[]string{"connection_id"},
+		append(baseMetricsLabels, "connection_id"),
 	)
 	prometheus.MustRegister(rttMax)
 
@@ -86,7 +86,7 @@ func newMuxerMetrics() *muxerMetrics {
 			Name: "argotunnel_receive_window_ave",
 			Help: "Average receive window size in bytes",
 		},
-		[]string{"connection_id"},
+		append(baseMetricsLabels, "connection_id"),
 	)
 	prometheus.MustRegister(receiveWindowAve)
 
@@ -95,7 +95,7 @@ func newMuxerMetrics() *muxerMetrics {
 			Name: "argotunnel_send_window_ave",
 			Help: "Average send window size in bytes",
 		},
-		[]string{"connection_id"},
+		append(baseMetricsLabels, "connection_id"),
 	)
 	prometheus.MustRegister(sendWindowAve)
 
@@ -104,7 +104,7 @@ func newMuxerMetrics() *muxerMetrics {
 			Name: "argotunnel_receive_window_min",
 			Help: "Smallest receive window size in bytes",
 		},
-		[]string{"connection_id"},
+		append(baseMetricsLabels, "connection_id"),
 	)
 	prometheus.MustRegister(receiveWindowMin)
 
@@ -113,7 +113,7 @@ func newMuxerMetrics() *muxerMetrics {
 			Name: "argotunnel_receive_window_max",
 			Help: "Largest receive window size in bytes",
 		},
-		[]string{"connection_id"},
+		append(baseMetricsLabels, "connection_id"),
 	)
 	prometheus.MustRegister(receiveWindowMax)
 
@@ -122,7 +122,7 @@ func newMuxerMetrics() *muxerMetrics {
 			Name: "argotunnel_send_window_min",
 			Help: "Smallest send window size in bytes",
 		},
-		[]string{"connection_id"},
+		append(baseMetricsLabels, "connection_id"),
 	)
 	prometheus.MustRegister(sendWindowMin)
 
@@ -131,7 +131,7 @@ func newMuxerMetrics() *muxerMetrics {
 			Name: "argotunnel_send_window_max",
 			Help: "Largest send window size in bytes",
 		},
-		[]string{"connection_id"},
+		append(baseMetricsLabels, "connection_id"),
 	)
 	prometheus.MustRegister(sendWindowMax)
 
@@ -140,7 +140,7 @@ func newMuxerMetrics() *muxerMetrics {
 			Name: "argotunnel_inbound_bytes_per_sec_curr",
 			Help: "Current inbounding bytes per second, 0 if there is no incoming connection",
 		},
-		[]string{"connection_id"},
+		append(baseMetricsLabels, "connection_id"),
 	)
 	prometheus.MustRegister(inBoundRateCurr)
 
@@ -149,7 +149,7 @@ func newMuxerMetrics() *muxerMetrics {
 			Name: "argotunnel_inbound_bytes_per_sec_min",
 			Help: "Minimum non-zero inbounding bytes per second",
 		},
-		[]string{"connection_id"},
+		append(baseMetricsLabels, "connection_id"),
 	)
 	prometheus.MustRegister(inBoundRateMin)
 
@@ -158,7 +158,7 @@ func newMuxerMetrics() *muxerMetrics {
 			Name: "argotunnel_inbound_bytes_per_sec_max",
 			Help: "Maximum inbounding bytes per second",
 		},
-		[]string{"connection_id"},
+		append(baseMetricsLabels, "connection_id"),
 	)
 	prometheus.MustRegister(inBoundRateMax)
 
@@ -167,7 +167,7 @@ func newMuxerMetrics() *muxerMetrics {
 			Name: "argotunnel_outbound_bytes_per_sec_curr",
 			Help: "Current outbounding bytes per second, 0 if there is no outgoing traffic",
 		},
-		[]string{"connection_id"},
+		append(baseMetricsLabels, "connection_id"),
 	)
 	prometheus.MustRegister(outBoundRateCurr)
 
@@ -176,7 +176,7 @@ func newMuxerMetrics() *muxerMetrics {
 			Name: "argotunnel_outbound_bytes_per_sec_min",
 			Help: "Minimum non-zero outbounding bytes per second",
 		},
-		[]string{"connection_id"},
+		append(baseMetricsLabels, "connection_id"),
 	)
 	prometheus.MustRegister(outBoundRateMin)
 
@@ -185,7 +185,7 @@ func newMuxerMetrics() *muxerMetrics {
 			Name: "argotunnel_outbound_bytes_per_sec_max",
 			Help: "Maximum outbounding bytes per second",
 		},
-		[]string{"connection_id"},
+		append(baseMetricsLabels, "connection_id"),
 	)
 	prometheus.MustRegister(outBoundRateMax)
 
@@ -231,7 +231,7 @@ func convertRTTMilliSec(t time.Duration) float64 {
 }
 
 // Metrics that can be collected without asking the edge
-func NewTunnelMetrics() *TunnelMetrics {
+func NewTunnelMetrics(baseMetricLabels []string) *TunnelMetrics {
 	haConnections := prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "argotunnel_ha_connections",
@@ -239,28 +239,21 @@ func NewTunnelMetrics() *TunnelMetrics {
 		})
 	prometheus.MustRegister(haConnections)
 
-	totalRequests := prometheus.NewCounter(
+	requests := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "argotunnel_total_requests",
-			Help: "Amount of requests proxied through all the tunnels",
-		})
-	prometheus.MustRegister(totalRequests)
-
-	requestsPerTunnel := prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "argotunnel_requests_per_tunnel",
+			Name: "argotunnel_requests",
 			Help: "Amount of requests proxied through each tunnel",
 		},
-		[]string{"connection_id"},
+		append(baseMetricLabels, "connection_id"),
 	)
-	prometheus.MustRegister(requestsPerTunnel)
+	prometheus.MustRegister(requests)
 
 	concurrentRequestsPerTunnel := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "argotunnel_concurrent_requests_per_tunnel",
 			Help: "Concurrent requests proxied through each tunnel",
 		},
-		[]string{"connection_id"},
+		append(baseMetricLabels, "connection_id"),
 	)
 	prometheus.MustRegister(concurrentRequestsPerTunnel)
 
@@ -269,7 +262,7 @@ func NewTunnelMetrics() *TunnelMetrics {
 			Name: "argotunnel_max_concurrent_requests_per_tunnel",
 			Help: "Largest number of concurrent requests proxied through each tunnel so far",
 		},
-		[]string{"connection_id"},
+		append(baseMetricLabels, "connection_id"),
 	)
 	prometheus.MustRegister(maxConcurrentRequestsPerTunnel)
 
@@ -289,38 +282,37 @@ func NewTunnelMetrics() *TunnelMetrics {
 	// )
 	// prometheus.MustRegister(responseByCode)
 
-	responseCodePerTunnel := prometheus.NewCounterVec(
+	responses := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "argotunnel_response_code_per_tunnel",
-			Help: "Count of responses by HTTP status code fore each tunnel",
+			Name: "argotunnel_responses",
+			Help: "Count of responses for each tunnel",
 		},
-		[]string{"connection_id", "status_code"},
+		append(baseMetricLabels, "connection_id", "status_code"),
 	)
-	prometheus.MustRegister(responseCodePerTunnel)
+	prometheus.MustRegister(responses)
 
 	serverLocations := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "argotunnel_server_locations",
 			Help: "Where each tunnel is connected to. 1 means current location, 0 means previous locations.",
 		},
-		[]string{"connection_id", "location"},
+		append(baseMetricLabels, "connection_id", "location"),
 	)
 	prometheus.MustRegister(serverLocations)
 
 	return &TunnelMetrics{
 		haConnections:                  haConnections,
-		totalRequests:                  totalRequests,
-		requests:                       requestsPerTunnel,
+		requests:                       requests,
 		concurrentRequestsPerTunnel:    concurrentRequestsPerTunnel,
 		concurrentRequests:             make(map[uint64]uint64),
 		maxConcurrentRequestsPerTunnel: maxConcurrentRequestsPerTunnel,
 		maxConcurrentRequests:          make(map[uint64]uint64),
 		timerRetries:                   timerRetries,
 
-		reponses:           responseCodePerTunnel,
+		responses:          responses,
 		serverLocations:    serverLocations,
 		oldServerLocations: make(map[uint64]string),
-		muxerMetrics:       newMuxerMetrics(),
+		muxerMetrics:       newMuxerMetrics(baseMetricLabels),
 	}
 }
 
@@ -362,7 +354,6 @@ func (t *TunnelMetrics) incrementRequests(metricLabelValues []string) {
 	}
 	t.concurrentRequestsLock.Unlock()
 
-	t.totalRequests.Inc()
 	t.requests.WithLabelValues(metricLabelValues...).Inc()
 	t.concurrentRequestsPerTunnel.WithLabelValues(metricLabelValues...).Inc()
 }
@@ -380,7 +371,7 @@ func (t *TunnelMetrics) decrementConcurrentRequests(metricLabelValues []string) 
 
 func (t *TunnelMetrics) incrementResponses(metricLabelValues []string, responseCode int) {
 	labelValues := append(metricLabelValues, strconv.Itoa(responseCode))
-	t.reponses.WithLabelValues(labelValues...).Inc()
+	t.responses.WithLabelValues(labelValues...).Inc()
 
 }
 

--- a/origin/metrics_test.go
+++ b/origin/metrics_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 // can only be called once
-var m = NewTunnelMetrics()
+var testMetrics = make([]string, 0)
+var m = NewTunnelMetrics(testMetrics)
 
 func TestConcurrentRequestsSingleTunnel(t *testing.T) {
 	routines := 20
@@ -92,7 +93,6 @@ func TestConcurrentRequestsMultiTunnel(t *testing.T) {
 	}
 
 }
-
 func TestRegisterServerLocation(t *testing.T) {
 	tunnels := 20
 	var wg sync.WaitGroup

--- a/origin/metrics_test.go
+++ b/origin/metrics_test.go
@@ -15,33 +15,37 @@ func TestConcurrentRequestsSingleTunnel(t *testing.T) {
 	routines := 20
 	var wg sync.WaitGroup
 	wg.Add(routines)
+
+	baseLabels := []string{"0"}
+	hashKey := hashLabelValues(baseLabels)
+
 	for i := 0; i < routines; i++ {
 		go func() {
-			m.incrementRequests("0")
+			m.incrementRequests(baseLabels)
 			wg.Done()
 		}()
 	}
 	wg.Wait()
 	assert.Len(t, m.concurrentRequests, 1)
-	assert.Equal(t, uint64(routines), m.concurrentRequests["0"])
+	assert.Equal(t, uint64(routines), m.concurrentRequests[hashKey])
 	assert.Len(t, m.maxConcurrentRequests, 1)
-	assert.Equal(t, uint64(routines), m.maxConcurrentRequests["0"])
+	assert.Equal(t, uint64(routines), m.maxConcurrentRequests[hashKey])
 
 	wg.Add(routines / 2)
 	for i := 0; i < routines/2; i++ {
 		go func() {
-			m.decrementConcurrentRequests("0")
+			m.decrementConcurrentRequests(baseLabels)
 			wg.Done()
 		}()
 	}
 	wg.Wait()
-	assert.Equal(t, uint64(routines-routines/2), m.concurrentRequests["0"])
-	assert.Equal(t, uint64(routines), m.maxConcurrentRequests["0"])
+	assert.Equal(t, uint64(routines-routines/2), m.concurrentRequests[hashKey])
+	assert.Equal(t, uint64(routines), m.maxConcurrentRequests[hashKey])
 }
 
 func TestConcurrentRequestsMultiTunnel(t *testing.T) {
-	m.concurrentRequests = make(map[string]uint64)
-	m.maxConcurrentRequests = make(map[string]uint64)
+	m.concurrentRequests = make(map[uint64]uint64)
+	m.maxConcurrentRequests = make(map[uint64]uint64)
 	tunnels := 20
 	var wg sync.WaitGroup
 	wg.Add(tunnels)
@@ -49,8 +53,8 @@ func TestConcurrentRequestsMultiTunnel(t *testing.T) {
 		go func(i int) {
 			// if we have j < i, then tunnel 0 won't have a chance to call incrementRequests
 			for j := 0; j < i+1; j++ {
-				id := strconv.Itoa(i)
-				m.incrementRequests(id)
+				labels := []string{strconv.Itoa(i)}
+				m.incrementRequests(labels)
 			}
 			wg.Done()
 		}(i)
@@ -60,17 +64,18 @@ func TestConcurrentRequestsMultiTunnel(t *testing.T) {
 	assert.Len(t, m.concurrentRequests, tunnels)
 	assert.Len(t, m.maxConcurrentRequests, tunnels)
 	for i := 0; i < tunnels; i++ {
-		id := strconv.Itoa(i)
-		assert.Equal(t, uint64(i+1), m.concurrentRequests[id])
-		assert.Equal(t, uint64(i+1), m.maxConcurrentRequests[id])
+		labels := []string{strconv.Itoa(i)}
+		hashKey := hashLabelValues(labels)
+		assert.Equal(t, uint64(i+1), m.concurrentRequests[hashKey])
+		assert.Equal(t, uint64(i+1), m.maxConcurrentRequests[hashKey])
 	}
 
 	wg.Add(tunnels)
 	for i := 0; i < tunnels; i++ {
 		go func(i int) {
 			for j := 0; j < i+1; j++ {
-				id := strconv.Itoa(i)
-				m.decrementConcurrentRequests(id)
+				labels := []string{strconv.Itoa(i)}
+				m.decrementConcurrentRequests(labels)
 			}
 			wg.Done()
 		}(i)
@@ -80,9 +85,10 @@ func TestConcurrentRequestsMultiTunnel(t *testing.T) {
 	assert.Len(t, m.concurrentRequests, tunnels)
 	assert.Len(t, m.maxConcurrentRequests, tunnels)
 	for i := 0; i < tunnels; i++ {
-		id := strconv.Itoa(i)
-		assert.Equal(t, uint64(0), m.concurrentRequests[id])
-		assert.Equal(t, uint64(i+1), m.maxConcurrentRequests[id])
+		labels := []string{strconv.Itoa(i)}
+		hashKey := hashLabelValues(labels)
+		assert.Equal(t, uint64(0), m.concurrentRequests[hashKey])
+		assert.Equal(t, uint64(i+1), m.maxConcurrentRequests[hashKey])
 	}
 
 }
@@ -93,29 +99,31 @@ func TestRegisterServerLocation(t *testing.T) {
 	wg.Add(tunnels)
 	for i := 0; i < tunnels; i++ {
 		go func(i int) {
-			id := strconv.Itoa(i)
-			m.registerServerLocation(id, "LHR")
+			labels := []string{strconv.Itoa(i)}
+			m.registerServerLocation(labels, "LHR")
 			wg.Done()
 		}(i)
 	}
 	wg.Wait()
 	for i := 0; i < tunnels; i++ {
-		id := strconv.Itoa(i)
-		assert.Equal(t, "LHR", m.oldServerLocations[id])
+		labels := []string{strconv.Itoa(i)}
+		hashKey := hashLabelValues(labels)
+		assert.Equal(t, "LHR", m.oldServerLocations[hashKey])
 	}
 
 	wg.Add(tunnels)
 	for i := 0; i < tunnels; i++ {
 		go func(i int) {
-			id := strconv.Itoa(i)
-			m.registerServerLocation(id, "AUS")
+			labels := []string{strconv.Itoa(i)}
+			m.registerServerLocation(labels, "AUS")
 			wg.Done()
 		}(i)
 	}
 	wg.Wait()
 	for i := 0; i < tunnels; i++ {
-		id := strconv.Itoa(i)
-		assert.Equal(t, "AUS", m.oldServerLocations[id])
+		labels := []string{strconv.Itoa(i)}
+		hashKey := hashLabelValues(labels)
+		assert.Equal(t, "AUS", m.oldServerLocations[hashKey])
 	}
 
 }

--- a/origin/tunnel.go
+++ b/origin/tunnel.go
@@ -542,6 +542,7 @@ func (h *TunnelHandler) ServeStream(stream *h2mux.MuxedStream) error {
 	h.logRequest(req, cfRay, lbProbe)
 	if websocket.IsWebSocketUpgrade(req) {
 		conn, response, err := websocket.ClientConnect(req, h.tlsConfig)
+		h.logger.WithFields(log.Fields{"connectionID": h.connectionID, "status": response.StatusCode}).Info("incrementResponses")
 		h.metrics.incrementResponses(h.getCombinedMetricsLabels(h.connectionID), response.StatusCode)
 		if err != nil {
 			h.logError(stream, err)
@@ -555,6 +556,7 @@ func (h *TunnelHandler) ServeStream(stream *h2mux.MuxedStream) error {
 		}
 	} else {
 		response, err := h.httpClient.RoundTrip(req)
+		h.logger.WithFields(log.Fields{"connectionID": h.connectionID, "status": response.StatusCode}).Info("incrementResponses")
 		h.metrics.incrementResponses(h.getCombinedMetricsLabels(h.connectionID), response.StatusCode)
 		if err != nil {
 			h.logError(stream, err)


### PR DESCRIPTION
Request for comments, will squash/rebase before continuing.

Adds a set of metrics label keys to the TunnelHandler and uses the TunnelHandler to send all metrics updated.  The base metrics labels are defined by the application and passed through and made available when the TunnelHandler is created.

See also branch at https://github.com/cloudflare/cloudflare-ingress-controller/tree/metrics.