### PR TITLE
cloudflared/linux_service: Add missing /etc/init.d shebang

### DIFF
--- a/cmd/cloudflared/linux_service.go
+++ b/cmd/cloudflared/linux_service.go
@@ -84,7 +84,8 @@ WantedBy=timers.target
 var sysvTemplate = ServiceTemplate{
 	Path:     "/etc/init.d/cloudflared",
 	FileMode: 0755,
-	Content: `# For RedHat and cousins:
+	Content: `#!/bin/sh
+# For RedHat and cousins:
 # chkconfig: 2345 99 01
 # description: Argo Tunnel agent
 # processname: {{.Path}}


### PR DESCRIPTION
When using sysv init scripts, `cloudflared` fails to start due to the
missing shebang interpreter line.

This patch adds the missing shebang.