### PR TITLE
adjust macOS launchctl to auto-restart/keepalive

### DIFF
--- a/cmd/cloudflared/macos_service.go
+++ b/cmd/cloudflared/macos_service.go
@@ -55,10 +55,7 @@ func newLaunchdTemplate(installPath, stdoutPath, stderrPath string) *ServiceTemp
 		<key>StandardErrorPath</key>
 		<string>%s</string>
 		<key>KeepAlive</key>
-		<dict>
-			<key>SuccessfulExit</key>
-			<false/>
-		</dict>
+		<true/>
 		<key>ThrottleInterval</key>
 		<integer>20</integer>
 	</dict>


### PR DESCRIPTION
I would like cloudflared to auto restart as i find the process often crashes with no error logs reported. Here is a PR for this simple change.