### PR TITLE
Build a docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.12 as builder
+WORKDIR /go/src/github.com/cloudflare/cloudflared/
+RUN apt-get update && apt-get install -y --no-install-recommends upx
+# Run after `apt-get update` to improve rebuild scenarios
+COPY . .
+RUN make cloudflared
+RUN upx --no-progress cloudflared
+
+FROM gcr.io/distroless/base
+COPY --from=builder /go/src/github.com/cloudflare/cloudflared/cloudflared /usr/local/bin/
+ENTRYPOINT ["cloudflared", "--no-autoupdate"]
+CMD ["version"]

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ clean:
 cloudflared: tunnel-deps
 	go build -v $(VERSION_FLAGS) $(IMPORT_PATH)/cmd/cloudflared
 
+.PHONY: container
+container:
+	docker build -t cloudflare/cloudflared:"$(VERSION)" .
+
 .PHONY: test
 test: vet
 	go test -v -race $(VERSION_FLAGS) ./...


### PR DESCRIPTION
The build phase makes the assumption that any capnproto-files are pre-processed before building in-docker. I personally prefer "add-on-change" for protos over add-on-compile since that may lead to a dirty build.

Chose to add this as a PR even though there's already an open one. Feel free to close if we should focus on one PR with a slightly different direction instead.

Finally, my comment in the previous PR (#89) set out to clone inside the container which likely is a safer approach for release builds, but copying tree allows us to do "developer"/in-transit builds.