### PR TITLE
tunneldns: Update reporting metrics for API breakage in CoreDNS.

### DIFF
--- a/tunneldns/metrics.go
+++ b/tunneldns/metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/metrics"
 	"github.com/coredns/coredns/plugin/metrics/vars"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/pkg/rcode"
@@ -37,7 +38,7 @@ func (p MetricsPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dn
 	status, err := plugin.NextOrFailure(p.Name(), p.Next, ctx, rw, r)
 
 	// Update built-in metrics
-	vars.Report(ctx, state, ".", rcode.ToString(rw.Rcode), rw.Len, rw.Start)
+	vars.Report(metrics.WithServer(ctx), state, ".", rcode.ToString(rw.Rcode), rw.Len, rw.Start)
 
 	return status, err
 }


### PR DESCRIPTION
Use the new metrics.WithServer(ctx) method to get a server name, as the vars.Report emethod name takes this as its first param.

API was broken by upstream PR: https://github.com/coredns/coredns/pull/2722 