### PR TITLE
Fix macOS launch daemon

### DIFF
--- a/cmd/cloudflared/macos_service.go
+++ b/cmd/cloudflared/macos_service.go
@@ -47,6 +47,7 @@ func newLaunchdTemplate(installPath, stdoutPath, stderrPath string) *ServiceTemp
 		<key>ProgramArguments</key>
 		<array>
 			<string>{{ .Path }}</string>
+			<string>proxy-dns</string>
 		</array>
 		<key>RunAtLoad</key>
 		<true/>


### PR DESCRIPTION
On macOS you'd start the proxy with '[sudo] cloudflared proxy-dns'. This launch daemon didn't start the proxy since the argument 'proxy-dns' was missing. This commit adds the argument to the launch daemon and now starting the proxy on system startup works as expected.