### PR TITLE
DoH: change the media type to application/dns-message

### DIFF
--- a/tunneldns/https_upstream.go
+++ b/tunneldns/https_upstream.go
@@ -82,7 +82,7 @@ func (u *UpstreamHTTPS) exchangeWireformat(msg []byte) ([]byte, error) {
 		return nil, errors.Wrap(err, "failed to create an HTTPS request")
 	}
 
-	req.Header.Add("Content-Type", "application/dns-udpwireformat")
+	req.Header.Add("Content-Type", "application/dns-message")
 	req.Host = u.endpoint.Hostname()
 
 	resp, err := u.client.Do(req)


### PR DESCRIPTION
The media type for DoH was changed from `application/dns-udpwireformat` to `application/dns-message` in May 2018.

Ref: RFC8484 section 6.