### PR TITLE
Do not allow TLS versions less than 1.2 in DoH client

### DIFF
--- a/tunneldns/https_upstream.go
+++ b/tunneldns/https_upstream.go
@@ -34,7 +34,7 @@ func NewUpstreamHTTPS(endpoint string) (Upstream, error) {
 	}
 
 	// Update TLS and HTTP client configuration
-	tls := &tls.Config{ServerName: u.Hostname()}
+	tls := &tls.Config{ServerName: u.Hostname() MinVersion: tls.VersionTLS12}
 	transport := &http.Transport{
 		TLSClientConfig:    tls,
 		DisableCompression: true,

--- a/tunneldns/https_upstream.go
+++ b/tunneldns/https_upstream.go
@@ -34,7 +34,7 @@ func NewUpstreamHTTPS(endpoint string) (Upstream, error) {
 	}
 
 	// Update TLS and HTTP client configuration
-	tls := &tls.Config{ServerName: u.Hostname() MinVersion: tls.VersionTLS12}
+	tls := &tls.Config{ServerName: u.Hostname(), MinVersion: tls.VersionTLS12}
 	transport := &http.Transport{
 		TLSClientConfig:    tls,
 		DisableCompression: true,


### PR DESCRIPTION
Added explicit MinVersion for TLS configuration.