### PR TITLE
Fix Docker build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.12 as builder
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
+ENV GOOS=linux
 WORKDIR /go/src/github.com/cloudflare/cloudflared/
 RUN apt-get update && apt-get install -y --no-install-recommends upx
 # Run after `apt-get update` to improve rebuild scenarios

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.12 as builder
 ENV GO111MODULE=on
+ENV CGO_ENABLED=0
 WORKDIR /go/src/github.com/cloudflare/cloudflared/
 RUN apt-get update && apt-get install -y --no-install-recommends upx
 # Run after `apt-get update` to improve rebuild scenarios

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:1.12 as builder
+ENV GO111MODULE=on
 WORKDIR /go/src/github.com/cloudflare/cloudflared/
 RUN apt-get update && apt-get install -y --no-install-recommends upx
 # Run after `apt-get update` to improve rebuild scenarios


### PR DESCRIPTION
Currently Docker containers fail to build on version 2019.11.0, this merge request makes the following changes to the Dockerfile:

- Sets `GO111MODULE=on` which ensures that Go module support is activated. This resolves the following errors during Docker builds:

> build flag -mod=vendor only valid when using modules
make: *** [Makefile:32: cloudflared] Error 1

- Disables cgo by setting `CGO_ENABLED=0` which gives us a static binary, this resolves dependency issues which resulted in following error during runtime:

> cloudflared: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by cloudflared)

- Ensures target OS `GOOS` is set to Linux for Docker builds.