### PR TITLE
bug(cloudflared): nil pointer deference on h2DictWriter Close()

### DIFF
--- a/h2mux/h2_dictionaries.go
+++ b/h2mux/h2_dictionaries.go
@@ -542,7 +542,10 @@ func (w *h2DictWriter) Write(p []byte) (n int, err error) {
 }
 
 func (w *h2DictWriter) Close() error {
-	return w.comp.Close()
+	if w.comp != nil {
+		return w.comp.Close()
+	}
+	return nil
 }
 
 // From http2/hpack


### PR DESCRIPTION
Unlike other h2DictWriter methods, the Close() method does check whether
w.comp is nil.

This PR adds a check for non nil compressor before attempting to close

Bug: #141