### PR TITLE
Fix the http connection pool of tunnel

### DIFF
--- a/cmd/cloudflared/tunnel/configuration.go
+++ b/cmd/cloudflared/tunnel/configuration.go
@@ -197,6 +197,7 @@ func prepareTunnelConfig(
 	httpTransport := &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
 		MaxIdleConns:          c.Int("proxy-keepalive-connections"),
+		MaxIdleConnsPerHost:   c.Int("proxy-keepalive-connections"),
 		IdleConnTimeout:       c.Duration("proxy-keepalive-timeout"),
 		TLSHandshakeTimeout:   c.Duration("proxy-tls-timeout"),
 		ExpectContinueTimeout: 1 * time.Second,


### PR DESCRIPTION
Set the `MaxIdleConnsPerHost` of `http.Transport` to `proxy-keepalive-connections`.

Setting only the `MaxIdleConns` is not enough, the `MaxIdleConnsPerHost` must be set as well.

Otherwise, `http.Transport` will use the `DefaultMaxIdleConnsPerHost`, which is 2,
and then the connection pool will have only 2 connections hold.