### PR TITLE
Fix timer scheduling for systemd update service (#133)

### DIFF
--- a/cmd/cloudflared/linux_service.go
+++ b/cmd/cloudflared/linux_service.go
@@ -73,7 +73,7 @@ ExecStart=/bin/bash -c '{{ .Path }} update; code=$?; if [ $code -eq 64 ]; then s
 Description=Update Argo Tunnel
 
 [Timer]
-OnUnitActiveSec=1d
+OnCalendar=daily
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
The `cloudflared-update.timer` is now scheduled correctly instead of displaying "n/a" for the next runtime in `systemctl list-timers cloudflared-update.timer`.

It may also be desirable to `enable` this service as mentioned in #133, but I didn't want to make that decision.