### PR TITLE
perf(cloudflared): reuse memory from buffer pool to get better throughput

### DIFF
--- a/buffer/pool.go
+++ b/buffer/pool.go
@@ -1,0 +1,27 @@
+package buffer
+
+import (
+	"sync"
+)
+
+type Pool struct {
+	buffers sync.Pool
+}
+
+func NewPool(bufferSize int) *Pool {
+	return &Pool{
+		buffers: sync.Pool{
+			New: func() interface{} {
+				return make([]byte, bufferSize)
+			},
+		},
+	}
+}
+
+func (p *Pool) Get() []byte {
+	return p.buffers.Get().([]byte)
+}
+
+func (p *Pool) Put(buf []byte) {
+	p.buffers.Put(buf)
+}

--- a/buffer/pool.go
+++ b/buffer/pool.go
@@ -5,6 +5,8 @@ import (
 )
 
 type Pool struct {
+	// A Pool must not be copied after first use.
+	// https://golang.org/pkg/sync/#Pool
 	buffers sync.Pool
 }
 


### PR DESCRIPTION
There are three lines of code using `io.CopyBuffer()` with `make([]byte, 512*1024)` directly.
And they will make the cloudflared be very busy on allocating and releasing memory and will threshold the tunnel throughput by increasing latency.

This PR try to replace these `make([]byte, 512*1024)` with a `sync.Pool` to avoid allocating the buffer on every requests.

Ref: https://github.com/cloudflare/cloudflared/issues/160