### PR TITLE
Tweak HTTP host header. Fixes #107

### DIFF
--- a/tunneldns/https_upstream.go
+++ b/tunneldns/https_upstream.go
@@ -83,7 +83,7 @@ func (u *UpstreamHTTPS) exchangeWireformat(msg []byte) ([]byte, error) {
 	}
 
 	req.Header.Add("Content-Type", "application/dns-message")
-	req.Host = u.endpoint.Hostname()
+	req.Host = u.endpoint.Host
 
 	resp, err := u.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
I finally got the the root cause of the odd behaviour in #107.

It's to do with the HTTP Host headers accepted by 1.1.1.1.

With this working example, you can see that curl automatically sets the Host request header to `[2606:4700:4700::1111]`:

    $ echo -n 'q80BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB' | base64 -D | curl -v -H 'content-type: application/dns-message' --data-binary @- https://[2606:4700:4700::1111]/dns-query -o -
    ...
    > Host: [2606:4700:4700::1111]
    ...
    < HTTP/2 200
    ...

In this non-working example, the Host header is force-set to `2606:4700:4700::1111` (without brackets, as cloudflared does) and the server returns the 403 error seen when trying to use the IPv6 server in cloudflared:

    $ echo -n 'q80BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB' | base64 -D | curl -v -H 'content-type: application/dns-message' --data-binary @- https://[2606:4700:4700::1111]/dns-query -o - -H 'Host: 2606:4700:4700::1111'
    ...
    > Host: 2606:4700:4700::1111
    ...
    < HTTP/2 403
    ...

The simple way I found to fix this was using `u.endpoint.Host` instead of `u.endpoint.Hostname()` to set the Host header, which doesn't strip out the brackets. I'm new to Go, so I don't know if that'll have any side effects, but at least the root cause is now known and some other solution can be found.