### PR TITLE
Fix supervisor segfault due to nil pointer access

### DIFF
--- a/origin/supervisor.go
+++ b/origin/supervisor.go
@@ -103,6 +103,7 @@ func NewSupervisor(config *TunnelConfig, u uuid.UUID) (*Supervisor, error) {
 		logger:            config.Logger.WithField("subsystem", "supervisor"),
 		jwtLock:           &sync.RWMutex{},
 		eventDigestLock:   &sync.RWMutex{},
+		connDigestLock:    &sync.RWMutex{},
 		bufferPool:        buffer.NewPool(512 * 1024),
 	}, nil
 }


### PR DESCRIPTION
The code was trying to access `connDigestLock.Lock()` causing a panic, because it wasn't intialized in `NewSupervisor`:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x48a70d]

goroutine 80 [running]:
sync.(*RWMutex).Lock(0x0)
	/usr/local/go/src/sync/rwmutex.go:98 +0x2d
github.com/cloudflare/cloudflared/origin.(*Supervisor).SetConnDigest(0xc00007a0d0, 0x0, 0x0, 0x0)
	/app/origin/supervisor.go:349 +0x43
github.com/cloudflare/cloudflared/origin.RegisterTunnel(0x1640d80, 0xc00079a780, 0x1644240, 0xc00007a0d0, 0xc00031a1e0, 0xc0000b09a0, 0xc00020ce00, 0x1239300, 0xc00078e4b0, 0x10, ...)
	/app/origin/tunnel.go:385 +0x4c4
github.com/cloudflare/cloudflared/origin.ServeTunnel.func2(0x0, 0x0)
	/app/origin/tunnel.go:293 +0x17a
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc00016d020, 0xc00091b680)
	/app/vendor/golang.org/x/sync/errgroup/errgroup.go:57 +0x59
created by golang.org/x/sync/errgroup.(*Group).Go
	/app/vendor/golang.org/x/sync/errgroup/errgroup.go:54 +0x66
```