### PR TITLE
proxy-dns: Allow setting the Host header via url hash

### DIFF
--- a/cmd/cloudflared/tunnel/cmd.go
+++ b/cmd/cloudflared/tunnel/cmd.go
@@ -129,8 +129,8 @@ func Commands() []*cli.Command {
 				},
 				&cli.StringSliceFlag{
 					Name:    "upstream",
-					Usage:   "Upstream endpoint URL, you can specify multiple endpoints for redundancy.",
-					Value:   cli.NewStringSlice("https://1.1.1.1/dns-query", "https://1.0.0.1/dns-query"),
+					Usage:   "Upstream endpoint URL, you can specify multiple endpoints for redundancy. If required, the Host header can be manually set by appending a hash to the URL.",
+					Value:   cli.NewStringSlice("https://1.1.1.1/dns-query", "https://[2606:4700:4700::1111]/dns-query", "https://1.0.0.1/dns-query", "https://[2606:4700:4700::1001]/dns-query"),
 					EnvVars: []string{"TUNNEL_DNS_UPSTREAM"},
 				},
 			},
@@ -934,8 +934,8 @@ func tunnelFlags(shouldHide bool) []cli.Flag {
 		}),
 		altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
 			Name:    "proxy-dns-upstream",
-			Usage:   "Upstream endpoint URL, you can specify multiple endpoints for redundancy.",
-			Value:   cli.NewStringSlice("https://1.1.1.1/dns-query", "https://1.0.0.1/dns-query"),
+			Usage:   "Upstream endpoint URL, you can specify multiple endpoints for redundancy. If required, the Host header can be manually set by appending a hash to the URL.",
+			Value:   cli.NewStringSlice("https://1.1.1.1/dns-query", "https://[2606:4700:4700::1111]/dns-query", "https://1.0.0.1/dns-query", "https://[2606:4700:4700::1001]/dns-query"),
 			EnvVars: []string{"TUNNEL_DNS_UPSTREAM"},
 			Hidden:  shouldHide,
 		}),

--- a/tunneldns/https_upstream.go
+++ b/tunneldns/https_upstream.go
@@ -35,6 +35,10 @@ func NewUpstreamHTTPS(endpoint string) (Upstream, error) {
 
 	// Update TLS and HTTP client configuration
 	tls := &tls.Config{ServerName: u.Hostname()}
+	if u.Fragment != "" {
+		// Allow server name override via anchor on the url
+		tls.ServerName = u.Fragment
+	}
 	transport := &http.Transport{
 		TLSClientConfig:    tls,
 		DisableCompression: true,
@@ -84,6 +88,10 @@ func (u *UpstreamHTTPS) exchangeWireformat(msg []byte) ([]byte, error) {
 
 	req.Header.Add("Content-Type", "application/dns-message")
 	req.Host = u.endpoint.Host
+	if u.endpoint.Fragment != "" {
+		// Allow server name override via anchor on the url
+		req.Host = u.endpoint.Fragment
+	}
 
 	resp, err := u.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Some DoH providers (namely Google) won't accept IP addresses in the Host header of DoH requests.

As I mentioned in #113, using dns.google with cloudflared currently requires using the url `https://dns.google/dns-query`. This however causes a bootstrapping issue if cloudflared has been set as the system's only resolver, as dns.google can't be resolved. dns.google therefore needs to be added to the system's host file. Even then, this solution is not ideal, as the host file can only define one IP address per hostname.

This PR allows the HTTP Host header and TLS verification name to be overridden by adding a hash/anchor/fragment to the end of the URL. In normal HTTP implementations, the segment of the URL after the hash is not sent to the server, and in DoH specifically, it serves no purpose.

After the implementation of this change, services that require a specific Host header like dns.google could be used with upstream settings like this:

```
proxy-dns-upstream:
 - https://8.8.8.8/dns-query#dns.google
 - https://8.8.4.4/dns-query#dns.google
 - https://[2001:4860:4860::8888]/dns-query#dns.google
 - https://[2001:4860:4860::8844]/dns-query#dns.google
```

I also added Cloudflare DNS's IPv6 addresses to the default DoH configuration while I was editing the argument list, as IPv6 support was fixed in #168.

Fixes #113 