### PR TITLE
added option to map a cname host to a local origin

### DIFF
--- a/cmd/cloudflared/tunnel/cmd.go
+++ b/cmd/cloudflared/tunnel/cmd.go
@@ -768,6 +768,12 @@ func tunnelFlags(shouldHide bool) []cli.Flag {
 			EnvVars: []string{"TUNNEL_HOSTNAME"},
 			Hidden:  shouldHide,
 		}),
+		altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
+			Name:    "host-to-origin",
+			Usage:   "Decalre a direct host to origin mapping i.e. host1.example.com=http://localhost:8080. This takes precedence over the single url mapping.",
+			EnvVars: []string{"HOST_TO_ORIGIN"},
+			Hidden:  shouldHide,
+		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:    "http-host-header",
 			Usage:   "Sets the HTTP Host header for the local webserver.",

--- a/cmd/cloudflared/tunnel/configuration.go
+++ b/cmd/cloudflared/tunnel/configuration.go
@@ -71,7 +71,7 @@ func logClientOptions(c *cli.Context) {
 		flags[flag] = c.Generic(flag)
 	}
 
-	sliceFlags := []string{"header", "tag", "proxy-dns-upstream", "upstream", "edge"}
+	sliceFlags := []string{"header", "tag", "proxy-dns-upstream", "upstream", "edge", "host-to-origin"}
 	for _, sliceFlag := range sliceFlags {
 		if len(c.StringSlice(sliceFlag)) > 0 {
 			flags[sliceFlag] = strings.Join(c.StringSlice(sliceFlag), ", ")
@@ -179,6 +179,15 @@ func prepareTunnelConfig(
 		return nil, errors.Wrap(err, "Error validating origin URL")
 	}
 
+	hostToOriginUrls := make(map[string]string)
+	hostToOrigins := c.StringSlice("host-to-origin")
+	for _, hostToOrigin := range hostToOrigins {
+		hostToOriginArr := strings.Split(hostToOrigin, "=")
+		if len(hostToOriginArr) == 2 {
+			hostToOriginUrls[hostToOriginArr[0]] = hostToOriginArr[1]
+		}
+	}
+
 	var originCert []byte
 	if !isFreeTunnel {
 		originCert, err = getOriginCert(c)
@@ -268,6 +277,7 @@ func prepareTunnelConfig(
 		NoChunkedEncoding:    c.Bool("no-chunked-encoding"),
 		OriginCert:           originCert,
 		OriginUrl:            originURL,
+		HostToOriginUrls:     hostToOriginUrls,
 		ReportedVersion:      version,
 		Retries:              c.Uint("retries"),
 		RunFromTerminal:      isRunningFromTerminal(),


### PR DESCRIPTION
This add support for multiple local origin through a single cloudflared process.
Config file example to use it is as follows:

```
hostname: public.opus.ai
 # default url that will use any requests not coming through cname hosts
url: http://192.168.3.10:8080
logfile: ./cloudflared.log
origincert: ./cert.pem
no-autoupdate: true
host-to-origin:
    # first service cnamed to public.example.com
    - service1.opus.ai=http://localhost:8080
    # second service cnamed to public.example.com
    - service2.opus.ai=http://192.168.3.10:8080
   .... # and so on
```


Note that each service still needs to be cnamed manually in cloudflare panel. It should be possible to use the api through the service itself but I haven't explored it yet.
