### PR TITLE
beautify package meta information generated by fpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,11 @@ define build_package
 	cp cloudflared $(PACKAGE_DIR)/cloudflared
 	cat cloudflared_man_template | sed -e 's/\$${VERSION}/$(VERSION)/; s/\$${DATE}/$(DATE)/' > $(PACKAGE_DIR)/cloudflared.1
 	fakeroot fpm -C $(PACKAGE_DIR) -s dir -t $(1) --$(1)-compression bzip2 \
+		--description 'Cloudflare Argo tunnel daemon' \
+		--vendor 'Cloudflare' \
+		--license 'Cloudflare Service Agreement' \
+		--url 'https://github.com/cloudflare/cloudflared' \
+		-m 'Cloudflare <support@cloudflare.com>' \
 		-a $(TARGET_ARCH) -v $(VERSION) -n cloudflared --after-install postinst.sh --after-remove postrm.sh \
 		cloudflared=$(INSTALL_BINDIR) cloudflared.1=$(MAN_DIR)
 endef


### PR DESCRIPTION
Current Debian and RPM meta information are very generic, e.g.
$ apt-cache show cloudflared
Package: cloudflared
Version: 2020.7.0
License: unknown
Vendor: @k8s-managed-krwtk.teamcity-agents.svc.cluster.local
Architecture: amd64
Maintainer: <@k8s-managed-krwtk.teamcity-agents.svc.cluster.local>
Installed-Size: 42883
Section: default
Priority: extra
Homepage: http://example.com/no-uri-given
Description: no description given

Move those generic settings to `FPM_COMMONG_FLAGS` and pass those
to fpm when building the package.