### PR TITLE
tag cloudflared docker image with latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ cloudflared: tunnel-deps
 
 .PHONY: container
 container:
-	docker build --build-arg=TARGET_ARCH=$(TARGET_ARCH) --build-arg=TARGET_OS=$(TARGET_OS) -t cloudflare/cloudflared-$(TARGET_OS)-$(TARGET_ARCH):"$(VERSION)" .
+	docker build --build-arg=TARGET_ARCH=$(TARGET_ARCH) --build-arg=TARGET_OS=$(TARGET_OS) -t cloudflare/cloudflared-$(TARGET_OS)-$(TARGET_ARCH):latest -t cloudflare/cloudflared-$(TARGET_OS)-$(TARGET_ARCH):"$(VERSION)" .
 
 .PHONY: test
 test: vet


### PR DESCRIPTION
This updates the docker build to also include the `latest` tag which should default to the latest version available (Fixes #242).
