### PR TITLE
Update link to documentation for running as a service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,32 @@
 # Argo Tunnel client
 
-Contains the command-line client and its libraries for Argo Tunnel, a tunneling daemon that proxies any local webserver through the Cloudflare network.
+Contains the command-line client for Argo Tunnel, a tunneling daemon that proxies any local webserver through the Cloudflare network. Extensive documentation can be found in the [Argo Tunnel section](https://developers.cloudflare.com/argo-tunnel/) of the Cloudflare Docs.
 
-## Getting started
+## Before you get started
 
-    go install github.com/cloudflare/cloudflared/cmd/cloudflared
+Before you use Argo Tunnel, you'll need to complete a few steps in the Cloudflare dashboard. The website you add to Cloudflare will be used to route traffic to your Tunnel.
+
+1. [Add a website to Cloudflare](https://support.cloudflare.com/hc/en-us/articles/201720164-Creating-a-Cloudflare-account-and-adding-a-website)
+2. [Change your domain nameservers to Cloudflare](https://support.cloudflare.com/hc/en-us/articles/205195708)
+
+## Installing `cloudflared`
+
+Downloads are available as standalone binaries, a Docker image, and Debian, RPM, and Homebrew packages. You can also find releases here on the `cloudflared` GitHub repository.
+
+* You can [install on macOS](https://developers.cloudflare.com/argo-tunnel/getting-started/installation#macos) via Homebrew or by downloading the [latest Darwin amd64 release](https://github.com/cloudflare/cloudflared/releases)
+* Binaries, Debian, and RPM packages for Linux [can be found here](https://developers.cloudflare.com/argo-tunnel/getting-started/installation#linux)
+* A Docker image of `cloudflared` is [available on DockerHub](https://hub.docker.com/r/cloudflare/cloudflared)
+* You can install on Windows machines with the [steps here](https://developers.cloudflare.com/argo-tunnel/getting-started/installation#windows)
 
 User documentation for Argo Tunnel can be found at https://developers.cloudflare.com/argo-tunnel/
+
+## Creating Tunnels and routing traffic
+
+Once installed, you can authenticate `cloudflared` into your Cloudflare account and begin creating Tunnels that serve traffic for hostnames in your account.
+
+* Create a Tunnel with [these instructions](https://developers.cloudflare.com/argo-tunnel/create-tunnel)
+* Route traffic to that Tunnel with [DNS records in Cloudflare](https://developers.cloudflare.com/argo-tunnel/routing-to-tunnel/dns) or with a [Cloudflare Load Balancer](https://developers.cloudflare.com/argo-tunnel/routing-to-tunnel/lb)
+
+## TryCloudflare
+
+Want to test Argo Tunnel before adding a website to Cloudflare? You can do so with TryCloudflare using the documentation [available here](https://developers.cloudflare.com/argo-tunnel/learning/trycloudflare).

--- a/cmd/cloudflared/macos_service.go
+++ b/cmd/cloudflared/macos_service.go
@@ -119,7 +119,7 @@ func installLaunchd(c *cli.Context) error {
 		logger.Infof("Installing Argo Tunnel client as an user launch agent. " +
 			"Note that Argo Tunnel client will only run when the user is logged in. " +
 			"If you want to run Argo Tunnel client at boot, install with root permission. " +
-			"For more information, visit https://developers.cloudflare.com/argo-tunnel/reference/service/")
+			"For more information, visit https://developers.cloudflare.com/argo-tunnel/create-tunnel/run-as-service")
 	}
 	etPath, err := os.Executable()
 	if err != nil {

--- a/cmd/cloudflared/updater/update.go
+++ b/cmd/cloudflared/updater/update.go
@@ -20,7 +20,7 @@ import (
 const (
 	DefaultCheckUpdateFreq        = time.Hour * 24
 	appID                         = "app_idCzgxYerVD"
-	noUpdateInShellMessage        = "cloudflared will not automatically update when run from the shell. To enable auto-updates, run cloudflared as a service: https://developers.cloudflare.com/argo-tunnel/reference/service/"
+	noUpdateInShellMessage        = "cloudflared will not automatically update when run from the shell. To enable auto-updates, run cloudflared as a service: https://developers.cloudflare.com/argo-tunnel/create-tunnel/run-as-service"
 	noUpdateOnWindowsMessage      = "cloudflared will not automatically update on Windows systems."
 	noUpdateManagedPackageMessage = "cloudflared will not automatically update if installed by a package manager."
 	isManagedInstallFile          = ".installedFromPackageManager"

--- a/cmd/cloudflared/windows_service.go
+++ b/cmd/cloudflared/windows_service.go
@@ -25,7 +25,7 @@ import (
 const (
 	windowsServiceName        = "Cloudflared"
 	windowsServiceDescription = "Argo Tunnel agent"
-	windowsServiceUrl         = "https://developers.cloudflare.com/argo-tunnel/reference/service/"
+	windowsServiceUrl         = "https://developers.cloudflare.com/argo-tunnel/create-tunnel/run-as-service"
 
 	recoverActionDelay      = time.Second * 20
 	failureCountResetPeriod = time.Hour * 24


### PR DESCRIPTION
When you run cloudflared in Linux, it'll say:

```
cloudflared will not automatically update when run from the shell.
To enable auto-updates, run cloudflared as a service:
https://developers.cloudflare.com/argo-tunnel/reference/service/
```

This documentation seems to be out of date, however, and [causing some confusion](https://github.com/cloudflare/cloudflared/issues/251).  There also doesn't seem to be a way to actually navigate to this page from the [Argo Tunnel docs](https://developers.cloudflare.com/argo-tunnel/).  Note that when you visit the link above, none of the sections in the table of contents on the left side of the page are expanded.

So, this PR replaces this link with what seems to be more up-to-date documentation at https://developers.cloudflare.com/argo-tunnel/create-tunnel/run-as-service.
