### PR TITLE
Add max upstream connections dns-proxy option

### DIFF
--- a/cmd/cloudflared/app_resolver_service.go
+++ b/cmd/cloudflared/app_resolver_service.go
@@ -11,8 +11,9 @@ const (
 	// ResolverServiceType is used to identify what kind of overwatch service this is
 	ResolverServiceType = "resolver"
 
-	LogFieldResolverAddress = "resolverAddress"
-	LogFieldResolverPort    = "resolverPort"
+	LogFieldResolverAddress          = "resolverAddress"
+	LogFieldResolverPort             = "resolverPort"
+	LogFieldResolverMaxUpstreamConns = "resolverMaxUpstreamConns"
 )
 
 // ResolverService is used to wrap the tunneldns package's DNS over HTTP
@@ -57,7 +58,7 @@ func (s *ResolverService) Shutdown() {
 func (s *ResolverService) Run() error {
 	// create a listener
 	l, err := tunneldns.CreateListener(s.resolver.AddressOrDefault(), s.resolver.PortOrDefault(),
-		s.resolver.UpstreamsOrDefault(), s.resolver.BootstrapsOrDefault(), s.log)
+		s.resolver.UpstreamsOrDefault(), s.resolver.BootstrapsOrDefault(), s.resolver.MaxUpstreamConnectionsOrDefault(), s.log)
 	if err != nil {
 		return err
 	}
@@ -74,6 +75,7 @@ func (s *ResolverService) Run() error {
 	resolverLog := s.log.With().
 		Str(LogFieldResolverAddress, s.resolver.AddressOrDefault()).
 		Uint16(LogFieldResolverPort, s.resolver.PortOrDefault()).
+		Int(LogFieldResolverMaxUpstreamConns, s.resolver.MaxUpstreamConnectionsOrDefault()).
 		Logger()
 
 	resolverLog.Info().Msg("Starting resolver")

--- a/cmd/cloudflared/config/model.go
+++ b/cmd/cloudflared/config/model.go
@@ -30,6 +30,7 @@ type DNSResolver struct {
 	Port       uint16   `json:"port,omitempty"`
 	Upstreams  []string `json:"upstreams,omitempty"`
 	Bootstraps []string `json:"bootstraps,omitempty"`
+	MaxUpstreamConnections int `json:"max_upstream_connections,omitempty"`
 }
 
 // Root is the base options to configure the service
@@ -59,6 +60,7 @@ func (r *DNSResolver) Hash() string {
 	io.WriteString(h, strings.Join(r.Bootstraps, ","))
 	io.WriteString(h, strings.Join(r.Upstreams, ","))
 	io.WriteString(h, fmt.Sprintf("%d", r.Port))
+	io.WriteString(h, fmt.Sprintf("%d", r.MaxUpstreamConnections))
 	io.WriteString(h, fmt.Sprintf("%v", r.Enabled))
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
@@ -98,4 +100,12 @@ func (r *DNSResolver) BootstrapsOrDefault() []string {
 		return r.Bootstraps
 	}
 	return []string{"https://162.159.36.1/dns-query", "https://162.159.46.1/dns-query", "https://[2606:4700:4700::1111]/dns-query", "https://[2606:4700:4700::1001]/dns-query"}
+}
+
+// MaxUpstreamConnectionsOrDefault return the max upstream connections or returns the default if 0
+func (r *DNSResolver) MaxUpstreamConnectionsOrDefault() int {
+    if r.MaxUpstreamConnections >= 0 {
+        return r.MaxUpstreamConnections
+    }
+    return 0
 }

--- a/cmd/cloudflared/config/model.go
+++ b/cmd/cloudflared/config/model.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/cloudflare/cloudflared/tunneldns"
 )
 
 // Forwarder represents a client side listener to forward traffic to the edge
@@ -25,12 +27,12 @@ type Tunnel struct {
 
 // DNSResolver represents a client side DNS resolver
 type DNSResolver struct {
-	Enabled    bool     `json:"enabled"`
-	Address    string   `json:"address,omitempty"`
-	Port       uint16   `json:"port,omitempty"`
-	Upstreams  []string `json:"upstreams,omitempty"`
-	Bootstraps []string `json:"bootstraps,omitempty"`
-	MaxUpstreamConnections int `json:"max_upstream_connections,omitempty"`
+	Enabled                bool     `json:"enabled"`
+	Address                string   `json:"address,omitempty"`
+	Port                   uint16   `json:"port,omitempty"`
+	Upstreams              []string `json:"upstreams,omitempty"`
+	Bootstraps             []string `json:"bootstraps,omitempty"`
+	MaxUpstreamConnections int      `json:"max_upstream_connections,omitempty"`
 }
 
 // Root is the base options to configure the service
@@ -102,10 +104,10 @@ func (r *DNSResolver) BootstrapsOrDefault() []string {
 	return []string{"https://162.159.36.1/dns-query", "https://162.159.46.1/dns-query", "https://[2606:4700:4700::1111]/dns-query", "https://[2606:4700:4700::1001]/dns-query"}
 }
 
-// MaxUpstreamConnectionsOrDefault return the max upstream connections or returns the default if 0
+// MaxUpstreamConnectionsOrDefault return the max upstream connections or returns the default if negative
 func (r *DNSResolver) MaxUpstreamConnectionsOrDefault() int {
-    if r.MaxUpstreamConnections >= 0 {
-        return r.MaxUpstreamConnections
-    }
-    return 0
+	if r.MaxUpstreamConnections >= 0 {
+		return r.MaxUpstreamConnections
+	}
+	return tunneldns.MaxUpstreamConnsDefault
 }

--- a/cmd/cloudflared/tunnel/cmd.go
+++ b/cmd/cloudflared/tunnel/cmd.go
@@ -1004,7 +1004,7 @@ func configureProxyDNSFlags(shouldHide bool) []cli.Flag {
 			Hidden:  shouldHide,
 		}),
 		altsrc.NewIntFlag(&cli.IntFlag{
-			Name:    tunneldns.MaxUpstreamConnsFlag,
+			Name:    "proxy-dns-max-upstream-conns",
 			Usage:   "Maximum concurrent connections to upstream. Setting to 0 means unlimited.",
 			Value:   tunneldns.MaxUpstreamConnsDefault,
 			Hidden:  shouldHide,

--- a/cmd/cloudflared/tunnel/cmd.go
+++ b/cmd/cloudflared/tunnel/cmd.go
@@ -1003,6 +1003,13 @@ func configureProxyDNSFlags(shouldHide bool) []cli.Flag {
 			EnvVars: []string{"TUNNEL_DNS_UPSTREAM"},
 			Hidden:  shouldHide,
 		}),
+		altsrc.NewIntFlag(&cli.IntFlag{
+			Name:    tunneldns.MaxUpstreamConnsFlag,
+			Usage:   "Maximum concurrent connections to upstream. Setting to 0 means unlimited.",
+			Value:   tunneldns.MaxUpstreamConnsDefault,
+			Hidden:  shouldHide,
+			EnvVars: []string{"TUNNEL_DNS_MAX_UPSTREAM_CONNS"},
+		}),
 		altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
 			Name:  "proxy-dns-bootstrap",
 			Usage: "bootstrap endpoint URL, you can specify multiple endpoints for redundancy.",

--- a/cmd/cloudflared/tunnel/server.go
+++ b/cmd/cloudflared/tunnel/server.go
@@ -15,9 +15,9 @@ func runDNSProxyServer(c *cli.Context, dnsReadySignal, shutdownC chan struct{}, 
 	if port <= 0 || port > 65535 {
 		return errors.New("The 'proxy-dns-port' must be a valid port number in <1, 65535> range.")
 	}
-	maxUpstreamConnections := c.Int(tunneldns.MaxUpstreamConnsFlag)
+	maxUpstreamConnections := c.Int("proxy-dns-max-upstream-conns")
 	if maxUpstreamConnections < 0 {
-		return fmt.Errorf("'%s' must be 0 or higher", tunneldns.MaxUpstreamConnsFlag)
+		return fmt.Errorf("'%s' must be 0 or higher", "proxy-dns-max-upstream-conns")
 	}
 	listener, err := tunneldns.CreateListener(c.String("proxy-dns-address"), uint16(port), c.StringSlice("proxy-dns-upstream"), c.StringSlice("proxy-dns-bootstrap"), maxUpstreamConnections, log)
 	if err != nil {

--- a/cmd/cloudflared/tunnel/server.go
+++ b/cmd/cloudflared/tunnel/server.go
@@ -1,6 +1,8 @@
 package tunnel
 
 import (
+	"fmt"
+
 	"github.com/cloudflare/cloudflared/tunneldns"
 
 	"github.com/pkg/errors"
@@ -13,9 +15,9 @@ func runDNSProxyServer(c *cli.Context, dnsReadySignal, shutdownC chan struct{}, 
 	if port <= 0 || port > 65535 {
 		return errors.New("The 'proxy-dns-port' must be a valid port number in <1, 65535> range.")
 	}
-	maxUpstreamConnections := c.Int("proxy-dns-max-upstream-conns")
+	maxUpstreamConnections := c.Int(tunneldns.MaxUpstreamConnsFlag)
 	if maxUpstreamConnections < 0 {
-		return errors.New("'proxy-dns-max-upstream-conns' must be 0 or higher")
+		return fmt.Errorf("'%s' must be 0 or higher", tunneldns.MaxUpstreamConnsFlag)
 	}
 	listener, err := tunneldns.CreateListener(c.String("proxy-dns-address"), uint16(port), c.StringSlice("proxy-dns-upstream"), c.StringSlice("proxy-dns-bootstrap"), maxUpstreamConnections, log)
 	if err != nil {

--- a/cmd/cloudflared/tunnel/server.go
+++ b/cmd/cloudflared/tunnel/server.go
@@ -13,7 +13,11 @@ func runDNSProxyServer(c *cli.Context, dnsReadySignal, shutdownC chan struct{}, 
 	if port <= 0 || port > 65535 {
 		return errors.New("The 'proxy-dns-port' must be a valid port number in <1, 65535> range.")
 	}
-	listener, err := tunneldns.CreateListener(c.String("proxy-dns-address"), uint16(port), c.StringSlice("proxy-dns-upstream"), c.StringSlice("proxy-dns-bootstrap"), log)
+	maxUpstreamConnections := c.Int("proxy-dns-max-upstream-conns")
+	if maxUpstreamConnections < 0 {
+		return errors.New("'proxy-dns-max-upstream-conns' must be 0 or higher")
+	}
+	listener, err := tunneldns.CreateListener(c.String("proxy-dns-address"), uint16(port), c.StringSlice("proxy-dns-upstream"), c.StringSlice("proxy-dns-bootstrap"), maxUpstreamConnections, log)
 	if err != nil {
 		close(dnsReadySignal)
 		listener.Stop()

--- a/tunneldns/https_upstream.go
+++ b/tunneldns/https_upstream.go
@@ -23,11 +23,10 @@ const (
 
 // UpstreamHTTPS is the upstream implementation for DNS over HTTPS service
 type UpstreamHTTPS struct {
-	client         *http.Client
-	endpoint       *url.URL
-	bootstraps     []string
-	maxConnections int
-	log            *zerolog.Logger
+	client     *http.Client
+	endpoint   *url.URL
+	bootstraps []string
+	log        *zerolog.Logger
 }
 
 // NewUpstreamHTTPS creates a new DNS over HTTPS upstream from endpoint
@@ -123,7 +122,7 @@ func configureBootstrap(bootstrap string) (*url.URL, *http.Client, error) {
 		return nil, nil, fmt.Errorf("bootstrap address of %s must be an IP address", b.Hostname())
 	}
 
-	return b, configureClient(b.Hostname(), 0), nil
+	return b, configureClient(b.Hostname(), MaxUpstreamConnsDefault), nil
 }
 
 // configureClient will configure a HTTPS client for upstream DoH requests

--- a/tunneldns/https_upstream.go
+++ b/tunneldns/https_upstream.go
@@ -23,19 +23,20 @@ const (
 
 // UpstreamHTTPS is the upstream implementation for DNS over HTTPS service
 type UpstreamHTTPS struct {
-	client     *http.Client
-	endpoint   *url.URL
-	bootstraps []string
-	log        *zerolog.Logger
+	client         *http.Client
+	endpoint       *url.URL
+	bootstraps     []string
+	maxConnections int
+	log            *zerolog.Logger
 }
 
 // NewUpstreamHTTPS creates a new DNS over HTTPS upstream from endpoint
-func NewUpstreamHTTPS(endpoint string, bootstraps []string, log *zerolog.Logger) (Upstream, error) {
+func NewUpstreamHTTPS(endpoint string, bootstraps []string, maxConnections int, log *zerolog.Logger) (Upstream, error) {
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
 	}
-	return &UpstreamHTTPS{client: configureClient(u.Hostname()), endpoint: u, bootstraps: bootstraps, log: log}, nil
+	return &UpstreamHTTPS{client: configureClient(u.Hostname(), maxConnections), endpoint: u, bootstraps: bootstraps, log: log}, nil
 }
 
 // Exchange provides an implementation for the Upstream interface
@@ -122,17 +123,18 @@ func configureBootstrap(bootstrap string) (*url.URL, *http.Client, error) {
 		return nil, nil, fmt.Errorf("bootstrap address of %s must be an IP address", b.Hostname())
 	}
 
-	return b, configureClient(b.Hostname()), nil
+	return b, configureClient(b.Hostname(), 0), nil
 }
 
 // configureClient will configure a HTTPS client for upstream DoH requests
-func configureClient(hostname string) *http.Client {
+func configureClient(hostname string, maxUpstreamConnections int) *http.Client {
 	// Update TLS and HTTP client configuration
 	tlsConfig := &tls.Config{ServerName: hostname}
 	transport := &http.Transport{
 		TLSClientConfig:    tlsConfig,
 		DisableCompression: true,
 		MaxIdleConns:       1,
+		MaxConnsPerHost:    maxUpstreamConnections,
 		Proxy:              http.ProxyFromEnvironment,
 	}
 	_ = http2.ConfigureTransport(transport)

--- a/tunneldns/tunnel.go
+++ b/tunneldns/tunnel.go
@@ -24,7 +24,7 @@ const (
 	LogFieldAddress         = "address"
 	LogFieldURL             = "url"
 	MaxUpstreamConnsFlag    = "max-upstream-conns"
-	MaxUpstreamConnsDefault = 10
+	MaxUpstreamConnsDefault = 5
 )
 
 // Listener is an adapter between CoreDNS server and Warp runnable

--- a/tunneldns/tunnel.go
+++ b/tunneldns/tunnel.go
@@ -23,7 +23,6 @@ import (
 const (
 	LogFieldAddress         = "address"
 	LogFieldURL             = "url"
-	MaxUpstreamConnsFlag    = "max-upstream-conns"
 	MaxUpstreamConnsDefault = 5
 )
 
@@ -71,7 +70,7 @@ func Command(hidden bool) *cli.Command {
 				EnvVars: []string{"TUNNEL_DNS_BOOTSTRAP"},
 			},
 			&cli.IntFlag{
-				Name:    MaxUpstreamConnsFlag,
+				Name:    "max-upstream-conns",
 				Usage:   "Maximum concurrent connections to upstream. Setting to 0 means unlimited.",
 				Value:   MaxUpstreamConnsDefault,
 				EnvVars: []string{"TUNNEL_DNS_MAX_UPSTREAM_CONNS"},
@@ -98,7 +97,7 @@ func Run(c *cli.Context) error {
 		uint16(c.Uint("port")),
 		c.StringSlice("upstream"),
 		c.StringSlice("bootstrap"),
-		c.Int(MaxUpstreamConnsFlag),
+		c.Int("max-upstream-conns"),
 		log,
 	)
 

--- a/tunneldns/tunnel.go
+++ b/tunneldns/tunnel.go
@@ -21,8 +21,10 @@ import (
 )
 
 const (
-	LogFieldAddress = "address"
-	LogFieldURL     = "url"
+	LogFieldAddress         = "address"
+	LogFieldURL             = "url"
+	MaxUpstreamConnsFlag    = "max-upstream-conns"
+	MaxUpstreamConnsDefault = 10
 )
 
 // Listener is an adapter between CoreDNS server and Warp runnable
@@ -69,9 +71,9 @@ func Command(hidden bool) *cli.Command {
 				EnvVars: []string{"TUNNEL_DNS_BOOTSTRAP"},
 			},
 			&cli.IntFlag{
-				Name:    "max-upstream-conns",
-				Usage:   "Maximum concurrent connections to upstream, unlimited by default",
-				Value:   0,
+				Name:    MaxUpstreamConnsFlag,
+				Usage:   "Maximum concurrent connections to upstream. Setting to 0 means unlimited.",
+				Value:   MaxUpstreamConnsDefault,
 				EnvVars: []string{"TUNNEL_DNS_MAX_UPSTREAM_CONNS"},
 			},
 		},
@@ -96,7 +98,7 @@ func Run(c *cli.Context) error {
 		uint16(c.Uint("port")),
 		c.StringSlice("upstream"),
 		c.StringSlice("bootstrap"),
-		c.Int("max-upstream-conns"),
+		c.Int(MaxUpstreamConnsFlag),
 		log,
 	)
 


### PR DESCRIPTION
Allows defining a limit to the number of connections that can be established with the upstream DNS host. If left unset, there may be situations where connections fail to establish, which causes the Transport to create an influx of connections causing upstream to throttle our requests and triggering a runaway effect resulting in high CPU usage.

This is a workaround for [the unresolved upstream connection issues](https://github.com/cloudflare/cloudflared/issues/23#issuecomment-687743790) that some people have reported occurring in Raspberry Pis running Pi-hole. By allowing users to cap the number of connections themselves to adjust them to the capacity of their specific device, we're at least mitigating against the impact this runaway effect has on the limited CPU resources these devices have.

```
Jan 09 17:38:46 hostname cloudflared[9896]: 5:38PM ERR failed to connect to an HTTPS backend "https://1.0.0.1/dns-query" error="failed to perform an HTTPS request: Post \"https://1.0.0.1/dns-query\": context deadline exceeded"
```

I'm currently running a cloudflared binary compiled with this changeset like so

```
cloudflared proxy-dns --port 54 --upstream https://1.1.1.1/dns-query --upstream https://1.0.0.1/dns-query --max-upstream-conns 5
```

Which brings down the %CPU of the cloudflared task in my Raspberry Pi 1 Model B from 80-98% to the 0-5% range.

This fix is based on @kitsook's [changeset](https://github.com/kitsook/cloudflared/commit/134410ae07e559743d50ee516b8b4a5111e01200). See #91 for more details about the issue.