### PR TITLE
Issue #285 - Makefile does not detect TARGET_ARCH correctly on FreeBSD 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ ifneq ($(GOARCH),)
     TARGET_ARCH ?= $(GOARCH)
 else ifeq ($(LOCAL_ARCH),x86_64)
     TARGET_ARCH ?= amd64
+else ifeq ($(LOCAL_ARCH),amd64)
+    TARGET_ARCH ?= amd64
 else ifeq ($(LOCAL_ARCH),i686)
     TARGET_ARCH ?= amd64
 else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 5),armv8)

--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ tunnelrpc/tunnelrpc.capnp.go: tunnelrpc/tunnelrpc.capnp
 .PHONY: vet
 vet:
 	go vet -mod=vendor ./...
-	which go-sumtype  # go get github.com/BurntSushi/go-sumtype
+	which go-sumtype  # go get github.com/BurntSushi/go-sumtype (don't do this in build directory or this will cause vendor issues)
 	go-sumtype $$(go list -mod=vendor ./...)
 
 .PHONY: msi


### PR DESCRIPTION
Simple Makefile fix for Issue #285 (Makefile does not detect TARGET_ARCH correctly on FreeBSD )

Build / runs tests cleanly on FreeBSD 12.2 (see [gmake.log](https://github.com/cloudflare/cloudflared/files/6055307/gmake.log))

(Note I added a note to the comment to the `make vet` target not to run `go get github.com/BurntSushi/go-sumtype` in the build dir as this causes a bunch of vendoring issues)
 
(Note - Issue discussion suggested @Michael9127 as reviewer but don't think I have permissions to assign this)