### PR TITLE
Fix macOS service installation launch template

### DIFF
--- a/cmd/cloudflared/macos_service.go
+++ b/cmd/cloudflared/macos_service.go
@@ -49,6 +49,8 @@ func newLaunchdTemplate(installPath, stdoutPath, stderrPath string) *ServiceTemp
 		<key>ProgramArguments</key>
 		<array>
 			<string>{{ .Path }}</string>
+			<string>tunnel</string>
+			<string>run</string>
 		</array>
 		<key>RunAtLoad</key>
 		<true/>


### PR DESCRIPTION
The current version of cloudflared (2021.3.2 at time of commit)
requires additional arguments to start a tunnel. Running 'cloudflared'
on its own does not run a tunnel with the default configuration.

This is behavior that has changed from previous versions of cloudflared,
where no arguments were required for starting/running a tunnel with the
default configuration behavior.

This fixes https://github.com/cloudflare/cloudflared/issues/327.