### PR TITLE
add CGO_ENABLED=0 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ ifeq ($(FIPS), true)
 	mv fips/fips.go.linux-amd64 fips/fips.go
 endif
 
-	GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) go build -v -mod=vendor $(GO_BUILD_TAGS) $(VERSION_FLAGS) $(IMPORT_PATH)/cmd/cloudflared
+	CGO_ENABLED=0 GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) go build -v -mod=vendor $(GO_BUILD_TAGS) $(VERSION_FLAGS) $(IMPORT_PATH)/cmd/cloudflared
 
 ifeq ($(FIPS), true)
 	mv fips/fips.go fips/fips.go.linux-amd64


### PR DESCRIPTION
Disable cgo to independent of the system glibc could avoid `TLS handshake timeout` in old glibc platform (eg: debian8 on openvz7)  and work better in alpine based docker image.