### PR TITLE
Fix broken TryCloudflare link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once installed, you can authenticate `cloudflared` into your Cloudflare account 
 
 ## TryCloudflare
 
-Want to test Argo Tunnel before adding a website to Cloudflare? You can do so with TryCloudflare using the documentation [available here](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/trycloudflare).
+Want to test Argo Tunnel before adding a website to Cloudflare? You can do so with TryCloudflare using the documentation [available here](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/do-more-with-tunnels/trycloudflare).
 
 ## Deprecated versions
 


### PR DESCRIPTION
Updates the link to TryCloudflare in README.md to point to the current documentation page.