### PR TITLE
Fix TryCloudflare link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once installed, you can authenticate `cloudflared` into your Cloudflare account 
 
 ## TryCloudflare
 
-Want to test Argo Tunnel before adding a website to Cloudflare? You can do so with TryCloudflare using the documentation [available here](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/do-more-with-tunnels/trycloudflare).
+Want to test Argo Tunnel before adding a website to Cloudflare? You can do so with TryCloudflare using the documentation [available here](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/run-tunnel/trycloudflare).
 
 ## Deprecated versions
 


### PR DESCRIPTION
Hi, I have updated the link to the [TryCloudflare](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/run-tunnel/trycloudflare) docs in this readme that seems to be broken.
