### PR TITLE
Add X-Forwarded-Host for http proxy

### DIFF
--- a/ingress/origin_proxy.go
+++ b/ingress/origin_proxy.go
@@ -40,6 +40,8 @@ func (o *httpService) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	if o.hostHeader != "" {
 		// For incoming requests, the Host header is promoted to the Request.Host field and removed from the Header map.
+		// Pass the original Host header as X-Forwarded-Host.
+		req.Header.Set("X-Forwarded-Host", req.Host)
 		req.Host = o.hostHeader
 	}
 	return o.transport.RoundTrip(req)


### PR DESCRIPTION
Adding [`X-Forwarded-Host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host) header to the http proxy.

This can be helpful in the case when the service in the ingress rule is another reverse proxy(call this 2nd reverse proxy), and the 2nd reverse proxy wants to pass original host to the backend application. So it becomes:

Original request:

```
mydns.on.cloudflare <---- customer request
        |
        |
cloudflared
  - hostname: mydns.on.cloudflare
    service: 2nd-proxy.some.internal
```

So in the `2nd-proxy.some.internal`, it listens ` 2nd-proxy.some.internal` and can read `$http_x_forwarded_host` and pass it to the application.

If the idea makes sense, maybe we want to add a new config option, as well as tests/docs update.