### PR TITLE
Fix for Issue #501: Unexpected User-agent insertion when tunneling http request

### DIFF
--- a/origin/proxy.go
+++ b/origin/proxy.go
@@ -177,6 +177,11 @@ func (p *Proxy) proxyHTTPRequest(
 		roundTripReq.Header.Set("Connection", "keep-alive")
 	}
 
+	// Set the User-Agent as an empty string if not provided to avoid inserting golang default UA
+	if roundTripReq.Header.Get("User-Agent") == "" {
+		roundTripReq.Header.Set("User-Agent", "")
+	}
+
 	resp, err := httpService.RoundTrip(roundTripReq)
 	if err != nil {
 		return errors.Wrap(err, "Unable to reach the origin service. The service may be down or it may not be responding to traffic from cloudflared")


### PR DESCRIPTION
When forwarding an UA-less request to the origin server cloudflared insert the default golang http User-Agent, this is unexpected and so can lead to issue.

This simple fix force setting the UA to the empty string when it isn't originaly provided.