### PR TITLE
Addressing h2mux and session flaky tests

### DIFF
--- a/h2mux/h2mux_test.go
+++ b/h2mux/h2mux_test.go
@@ -823,7 +823,7 @@ func TestMultipleStreamsWithDictionaries(t *testing.T) {
 		}
 
 		originMuxMetrics := muxPair.OriginMux.Metrics()
-		if q > CompressionNone && originMuxMetrics.CompBytesBefore.Value() <= 10*originMuxMetrics.CompBytesAfter.Value() {
+		if q > CompressionNone && CompressionIsSupported() && originMuxMetrics.CompBytesBefore.Value() <= 10*originMuxMetrics.CompBytesAfter.Value() {
 			t.Fatalf("Cross-stream compression is expected to give a better compression ratio")
 		}
 	}
@@ -952,7 +952,7 @@ func TestSampleSiteWithDictionaries(t *testing.T) {
 		}
 
 		originMuxMetrics := muxPair.OriginMux.Metrics()
-		if q > CompressionNone && originMuxMetrics.CompBytesBefore.Value() <= 10*originMuxMetrics.CompBytesAfter.Value() {
+		if q > CompressionNone && CompressionIsSupported() && originMuxMetrics.CompBytesBefore.Value() <= 10*originMuxMetrics.CompBytesAfter.Value() {
 			t.Fatalf("Cross-stream compression is expected to give a better compression ratio")
 		}
 	}
@@ -985,8 +985,8 @@ func TestLongSiteWithDictionaries(t *testing.T) {
 		assert.NoError(t, errGroup.Wait())
 
 		originMuxMetrics := muxPair.OriginMux.Metrics()
-		if q > CompressionNone && originMuxMetrics.CompBytesBefore.Value() <= 10*originMuxMetrics.CompBytesAfter.Value() {
-			t.Fatalf("Cross-stream compression is expected to give a better compression ratio")
+		if q > CompressionNone && CompressionIsSupported() && originMuxMetrics.CompBytesBefore.Value() <= 10*originMuxMetrics.CompBytesAfter.Value() {
+			t.Fatalf("Cross-stream compression (%d) is expected to give a better compression ratio: %d <= %d", q, originMuxMetrics.CompBytesBefore.Value(), 10*originMuxMetrics.CompBytesAfter.Value())
 		}
 	}
 }

--- a/h2mux/h2mux_test.go
+++ b/h2mux/h2mux_test.go
@@ -986,7 +986,7 @@ func TestLongSiteWithDictionaries(t *testing.T) {
 
 		originMuxMetrics := muxPair.OriginMux.Metrics()
 		if q > CompressionNone && CompressionIsSupported() && originMuxMetrics.CompBytesBefore.Value() <= 10*originMuxMetrics.CompBytesAfter.Value() {
-			t.Fatalf("Cross-stream compression (%d) is expected to give a better compression ratio: %d <= %d", q, originMuxMetrics.CompBytesBefore.Value(), 10*originMuxMetrics.CompBytesAfter.Value())
+			t.Fatalf("Cross-stream compression is expected to give a better compression ratio")
 		}
 	}
 }


### PR DESCRIPTION
Updating some tests to try and appease CI flaky tests.

- Correct some h2mux tests on windows without CGO_ENABLED: Compression isn't supported without cgo on windows environments so the h2mux tests need to ignore compression.
   - TestMultipleStreamsWithDictionaries, TestSampleSiteWithDictionaries, TestLongSiteWithDictionaries
- TestReadFromDstSessionPreventClosed occasionally will fail because the session closes in the idle time. This might be because of all the tests running in parallel in separate goroutines and the 100ms time limit is exceeded. Bumping this idle time and execution window up may help reduce the flaky failures for these tests