### PR TITLE
Set ForceAttemptHTTP2 on http.Transport to auto support HTTP/2

### DIFF
--- a/ingress/origin_service.go
+++ b/ingress/origin_service.go
@@ -284,6 +284,7 @@ func newHTTPTransport(service OriginService, cfg OriginRequestConfig, log *zerol
 		TLSHandshakeTimeout:   cfg.TLSTimeout.Duration,
 		ExpectContinueTimeout: 1 * time.Second,
 		TLSClientConfig:       &tls.Config{RootCAs: originCertPool, InsecureSkipVerify: cfg.NoTLSVerify},
+		ForceAttemptHTTP2:     true,
 	}
 	if _, isHelloWorld := service.(*helloWorld); !isHelloWorld && cfg.OriginServerName != "" {
 		httpTransport.TLSClientConfig.ServerName = cfg.OriginServerName

--- a/tunneldns/https_upstream.go
+++ b/tunneldns/https_upstream.go
@@ -135,6 +135,7 @@ func configureClient(hostname string, maxUpstreamConnections int) *http.Client {
 		MaxIdleConns:       1,
 		MaxConnsPerHost:    maxUpstreamConnections,
 		Proxy:              http.ProxyFromEnvironment,
+		ForceAttemptHTTP2:  true,
 	}
 	_ = http2.ConfigureTransport(transport)
 


### PR DESCRIPTION
[`ForceAttempHTTP2` doc](https://github.com/golang/go/blob/go1.17.9/src/net/http/transport.go#L278-L283):
```go
    ...
    // ForceAttemptHTTP2 controls whether HTTP/2 is enabled when a non-zero
    // Dial, DialTLS, or DialContext func or TLSClientConfig is provided.
    // By default, use of any those fields conservatively disables HTTP/2.
    // To use a custom dialer or TLS config and still attempt HTTP/2
    // upgrades, set this to true.
    ForceAttemptHTTP2 bool
    ...
```

Found two instances of `http.Transport` instantiations where it needed to set `ForceAttemptHTTP2` boolean, in order to automatically enable HTTP/2 support; others are not needy, according to docs.

> Just to mention, there is also the [`http2.ConfigureTransport`](https://pkg.go.dev/golang.org/x/net/http2#ConfigureTransport) function that enables HTTP/2 support for an `http.Transport` instance, the **manual** way; it's used once in the [Cloudflare API base client](https://github.com/cloudflare/cloudflared/blob/8a07a900fde36efe48fd27ad5f974273015e8270/cfapi/base_client.go#L71).

Closes #625.