### PR TITLE
Add image source label to docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ENV GO111MODULE=on \
     CGO_ENABLED=0 \
     TARGET_GOOS=${TARGET_GOOS} \
     TARGET_GOARCH=${TARGET_GOARCH}
+    
+LABEL org.opencontainers.image.source="https://github.com/cloudflare/cloudflared"
 
 WORKDIR /go/src/github.com/cloudflare/cloudflared/
 


### PR DESCRIPTION
This label allows tools like [whitesource renovate](https://docs.renovatebot.com/modules/datasource/#docker-datasource) to find changelogs.