### PR TITLE
Fix: Replace TARGET_GOOS and TARGET_GOARCH with TARGET_OS and TARGET_ARCH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,12 @@
 ARG TARGET_GOOS
 ARG TARGET_GOARCH
 FROM golang:1.17.1 as builder
+ARG TARGET_GOOS
+ARG TARGET_GOARCH
 ENV GO111MODULE=on \
     CGO_ENABLED=0 \
-    TARGET_GOOS=${TARGET_GOOS} \
-    TARGET_GOARCH=${TARGET_GOARCH}
+    TARGET_OS=${TARGET_GOOS} \
+    TARGET_ARCH=${TARGET_GOARCH}
     
 LABEL org.opencontainers.image.source="https://github.com/cloudflare/cloudflared"
 


### PR DESCRIPTION
There is a mismatch between the environment name in the docker file and what the makefile is expecting:
* https://github.com/cloudflare/cloudflared/blob/master/Makefile#L78
* https://github.com/cloudflare/cloudflared/blob/master/Makefile#L69

You also need to declare the `ARG` inside the `FROM` if you intend to use it in the build stage. See https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact