### PR TITLE
Issue #672: Run cloudflared service without root

### DIFF
--- a/cmd/cloudflared/linux_service.go
+++ b/cmd/cloudflared/linux_service.go
@@ -273,7 +273,7 @@ func installSystemd(templateArgs *ServiceTemplateArgs, log *zerolog.Logger) erro
 		}
 	}
 	// Create the cloudflared user if it does not exist
-	if err := runCommand("grep", "-qw", fmt.Sprintf("^%s", cloudflaredUser), "/etc/passwd"); err != nil {
+    if err := runCommand("grep", "-q", fmt.Sprintf("^%s:", cloudflaredUser), "/etc/passwd"); err != nil {
 		if err := runCommand("useradd", "--system", "--no-create-home", "--home-dir=/nonexistent", "--shell=/usr/sbin/nologin", cloudflaredUser); err != nil {
 			log.Err(err).Msgf("useradd %s error", cloudflaredUser)
 			return err
@@ -350,7 +350,7 @@ func uninstallSystemd(log *zerolog.Logger) error {
 		return err
 	}
 	// Delete the cloudflared user if it exists
-	if err := runCommand("grep", "-qw", fmt.Sprintf("^%s", cloudflaredUser), "/etc/passwd"); err == nil {
+    if err := runCommand("grep", "-q", fmt.Sprintf("^%s:", cloudflaredUser), "/etc/passwd"); err == nil {
 		if err := runCommand("userdel", cloudflaredUser); err != nil {
 			log.Err(err).Msgf("userdel %s error", cloudflaredUser)
 			return err

--- a/cmd/cloudflared/linux_service.go
+++ b/cmd/cloudflared/linux_service.go
@@ -273,7 +273,7 @@ func installSystemd(templateArgs *ServiceTemplateArgs, log *zerolog.Logger) erro
 		}
 	}
 	// Create the cloudflared user if it does not exist
-	if err := runCommand("grep", "-q", fmt.Sprintf("^%s:", cloudflaredUser), "/etc/passwd"); err != nil {
+	if err := runCommand("id", cloudflaredUser); err != nil {
 		if err := runCommand("useradd", "--system", "--no-create-home", "--home-dir=/nonexistent", "--shell=/usr/sbin/nologin", cloudflaredUser); err != nil {
 			log.Err(err).Msgf("useradd %s error", cloudflaredUser)
 			return err
@@ -350,7 +350,7 @@ func uninstallSystemd(log *zerolog.Logger) error {
 		return err
 	}
 	// Delete the cloudflared user if it exists
-	if err := runCommand("grep", "-q", fmt.Sprintf("^%s:", cloudflaredUser), "/etc/passwd"); err == nil {
+	if err := runCommand("id", cloudflaredUser); err == nil {
 		if err := runCommand("userdel", cloudflaredUser); err != nil {
 			log.Err(err).Msgf("userdel %s error", cloudflaredUser)
 			return err

--- a/cmd/cloudflared/linux_service.go
+++ b/cmd/cloudflared/linux_service.go
@@ -273,7 +273,7 @@ func installSystemd(templateArgs *ServiceTemplateArgs, log *zerolog.Logger) erro
 		}
 	}
 	// Create the cloudflared user if it does not exist
-    if err := runCommand("grep", "-q", fmt.Sprintf("^%s:", cloudflaredUser), "/etc/passwd"); err != nil {
+	if err := runCommand("grep", "-q", fmt.Sprintf("^%s:", cloudflaredUser), "/etc/passwd"); err != nil {
 		if err := runCommand("useradd", "--system", "--no-create-home", "--home-dir=/nonexistent", "--shell=/usr/sbin/nologin", cloudflaredUser); err != nil {
 			log.Err(err).Msgf("useradd %s error", cloudflaredUser)
 			return err
@@ -350,12 +350,12 @@ func uninstallSystemd(log *zerolog.Logger) error {
 		return err
 	}
 	// Delete the cloudflared user if it exists
-    if err := runCommand("grep", "-q", fmt.Sprintf("^%s:", cloudflaredUser), "/etc/passwd"); err == nil {
+	if err := runCommand("grep", "-q", fmt.Sprintf("^%s:", cloudflaredUser), "/etc/passwd"); err == nil {
 		if err := runCommand("userdel", cloudflaredUser); err != nil {
 			log.Err(err).Msgf("userdel %s error", cloudflaredUser)
 			return err
 		}
-    }
+	}
 	for _, serviceTemplate := range systemdTemplates {
 		if err := serviceTemplate.Remove(); err != nil {
 			log.Err(err).Msg("error removing service template")

--- a/cmd/cloudflared/service_template.go
+++ b/cmd/cloudflared/service_template.go
@@ -25,6 +25,7 @@ type ServiceTemplate struct {
 type ServiceTemplateArgs struct {
 	Path      string
 	ExtraArgs []string
+	User string
 }
 
 func (st *ServiceTemplate) ResolvePath() (string, error) {


### PR DESCRIPTION
Run the cloudflared service with `cloudflared` user

* Create user `cloudflared` if it does not exist in `cloudflared service install`
* Remove user `cloudflared` in `cloudflared service uninstall`
* Add `User=cloudflared` in `/etc/systemd/system/cloudflared.service`

Note: this only works for systemd.

I tested it in our environment and it worked :)

![cloudflared-service-up](https://user-images.githubusercontent.com/4235177/191044789-14e34ffc-bc2f-4b04-986e-b0a2804f5ac8.png)

Closes #672 