### PR TITLE
Add ingress.Rule Rewrite

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -177,11 +177,11 @@ func ValidateUrl(c *cli.Context, allowURLFromArgs bool) (*url.URL, error) {
 }
 
 type UnvalidatedIngressRule struct {
-	Hostname        string              `json:"hostname,omitempty"`
-	Path            string              `json:"path,omitempty"`
-	PathReplacement string              `yaml:"pathReplacement" json:"pathReplacement,omitempty"`
-	Service         string              `json:"service,omitempty"`
-	OriginRequest   OriginRequestConfig `yaml:"originRequest" json:"originRequest"`
+	Hostname      string              `json:"hostname,omitempty"`
+	Path          string              `json:"path,omitempty"`
+	Rewrite       string              `json:"rewrite,omitempty"`
+	Service       string              `json:"service,omitempty"`
+	OriginRequest OriginRequestConfig `yaml:"originRequest" json:"originRequest"`
 }
 
 // OriginRequestConfig is a set of optional fields that users may set to

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -177,10 +177,11 @@ func ValidateUrl(c *cli.Context, allowURLFromArgs bool) (*url.URL, error) {
 }
 
 type UnvalidatedIngressRule struct {
-	Hostname      string              `json:"hostname,omitempty"`
-	Path          string              `json:"path,omitempty"`
-	Service       string              `json:"service,omitempty"`
-	OriginRequest OriginRequestConfig `yaml:"originRequest" json:"originRequest"`
+	Hostname        string              `json:"hostname,omitempty"`
+	Path            string              `json:"path,omitempty"`
+	PathReplacement string              `yaml:"pathReplacement" json:"pathReplacement,omitempty"`
+	Service         string              `json:"service,omitempty"`
+	OriginRequest   OriginRequestConfig `yaml:"originRequest" json:"originRequest"`
 }
 
 // OriginRequestConfig is a set of optional fields that users may set to

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -13,9 +13,10 @@ import (
 func TestConfigFileSettings(t *testing.T) {
 	var (
 		firstIngress = UnvalidatedIngressRule{
-			Hostname: "tunnel1.example.com",
-			Path:     "/id",
-			Service:  "https://localhost:8000",
+			Hostname:        "tunnel1.example.com",
+			Path:            "/id",
+			PathReplacement: "/id",
+			Service:         "https://localhost:8000",
 		}
 		secondIngress = UnvalidatedIngressRule{
 			Hostname: "*",
@@ -45,6 +46,7 @@ originRequest:
 ingress:
  - hostname: tunnel1.example.com
    path: /id
+   pathReplacement: /id
    service: https://localhost:8000
  - hostname: "*"
    service: https://localhost:8001

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -13,10 +13,10 @@ import (
 func TestConfigFileSettings(t *testing.T) {
 	var (
 		firstIngress = UnvalidatedIngressRule{
-			Hostname:        "tunnel1.example.com",
-			Path:            "/id",
-			PathReplacement: "/id",
-			Service:         "https://localhost:8000",
+			Hostname: "tunnel1.example.com",
+			Path:     "/id",
+			Rewrite:  "/id",
+			Service:  "https://localhost:8000",
 		}
 		secondIngress = UnvalidatedIngressRule{
 			Hostname: "*",
@@ -46,7 +46,7 @@ originRequest:
 ingress:
  - hostname: tunnel1.example.com
    path: /id
-   pathReplacement: /id
+   rewrite: /id
    service: https://localhost:8000
  - hostname: "*"
    service: https://localhost:8001

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -294,6 +294,8 @@ func validateIngress(ingress []config.UnvalidatedIngressRule, defaults OriginReq
 				return Ingress{}, errors.Wrapf(err, "Rule #%d has an invalid regex", i+1)
 			}
 			pathRegexp = &Regexp{Regexp: regex}
+		} else if r.PathReplacement != "" {
+			return Ingress{}, fmt.Errorf("rule #%d has a path replacement without a path specified", i+1)
 		}
 
 		rules[i] = Rule{
@@ -301,6 +303,7 @@ func validateIngress(ingress []config.UnvalidatedIngressRule, defaults OriginReq
 			punycodeHostname: punycodeHostname,
 			Service:          service,
 			Path:             pathRegexp,
+			PathReplacement:  r.PathReplacement,
 			Handlers:         handlers,
 			Config:           cfg,
 		}

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -294,8 +294,8 @@ func validateIngress(ingress []config.UnvalidatedIngressRule, defaults OriginReq
 				return Ingress{}, errors.Wrapf(err, "Rule #%d has an invalid regex", i+1)
 			}
 			pathRegexp = &Regexp{Regexp: regex}
-		} else if r.PathReplacement != "" {
-			return Ingress{}, fmt.Errorf("rule #%d has a path replacement without a path specified", i+1)
+		} else if r.Rewrite != "" {
+			return Ingress{}, fmt.Errorf("rule #%d has a rewrite without a path specified", i+1)
 		}
 
 		rules[i] = Rule{
@@ -303,7 +303,7 @@ func validateIngress(ingress []config.UnvalidatedIngressRule, defaults OriginReq
 			punycodeHostname: punycodeHostname,
 			Service:          service,
 			Path:             pathRegexp,
-			PathReplacement:  r.PathReplacement,
+			Rewrite:          r.Rewrite,
 			Handlers:         handlers,
 			Config:           cfg,
 		}

--- a/ingress/ingress_test.go
+++ b/ingress/ingress_test.go
@@ -445,6 +445,41 @@ ingress:
 `},
 			wantErr: true,
 		},
+		{
+			name: "Path replacement",
+			args: args{rawYAML: `
+ingress:
+- hostname: test.example.com
+  service: https://localhost:8000
+  path: ^/api/(.*)$
+  pathReplacement: /$1
+- service: http_status:404
+`},
+			want: []Rule{
+				{
+					Hostname:        "test.example.com",
+					Service:         &httpService{url: localhost8000},
+					Path:            &Regexp{Regexp: regexp.MustCompile("^/api/(.*)$")},
+					PathReplacement: "/$1",
+					Config:          defaultConfig,
+				},
+				{
+					Service: &fourOhFour,
+					Config:  defaultConfig,
+				},
+			},
+		},
+		{
+			name: "Path replacement without a path specified",
+			args: args{rawYAML: `
+ingress:
+- hostname: test.example.com
+  service: https://localhost:8000
+  pathReplacement: /$1
+- service: http_status:404
+`},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/ingress/ingress_test.go
+++ b/ingress/ingress_test.go
@@ -452,16 +452,16 @@ ingress:
 - hostname: test.example.com
   service: https://localhost:8000
   path: ^/api/(.*)$
-  pathReplacement: /$1
+  rewrite: /$1
 - service: http_status:404
 `},
 			want: []Rule{
 				{
-					Hostname:        "test.example.com",
-					Service:         &httpService{url: localhost8000},
-					Path:            &Regexp{Regexp: regexp.MustCompile("^/api/(.*)$")},
-					PathReplacement: "/$1",
-					Config:          defaultConfig,
+					Hostname: "test.example.com",
+					Service:  &httpService{url: localhost8000},
+					Path:     &Regexp{Regexp: regexp.MustCompile("^/api/(.*)$")},
+					Rewrite:  "/$1",
+					Config:   defaultConfig,
 				},
 				{
 					Service: &fourOhFour,
@@ -475,7 +475,7 @@ ingress:
 ingress:
 - hostname: test.example.com
   service: https://localhost:8000
-  pathReplacement: /$1
+  rewrite: /$1
 - service: http_status:404
 `},
 			wantErr: true,

--- a/ingress/ingress_test.go
+++ b/ingress/ingress_test.go
@@ -446,7 +446,7 @@ ingress:
 			wantErr: true,
 		},
 		{
-			name: "Path replacement",
+			name: "Rewrite",
 			args: args{rawYAML: `
 ingress:
 - hostname: test.example.com
@@ -470,7 +470,7 @@ ingress:
 			},
 		},
 		{
-			name: "Path replacement without a path specified",
+			name: "Rewrite without a path specified",
 			args: args{rawYAML: `
 ingress:
 - hostname: test.example.com

--- a/ingress/rule.go
+++ b/ingress/rule.go
@@ -20,6 +20,10 @@ type Rule struct {
 	// Path is an optional regex that can specify path-driven ingress rules.
 	Path *Regexp `json:"path"`
 
+	// PathReplacement is an optional regexp replacement string for Path,
+	// that gets sent to the Service
+	PathReplacement string `json:"pathReplacement"`
+
 	// A (probably local) address. Requests for a hostname which matches this
 	// rule's hostname pattern will be proxied to the service running on this
 	// address.

--- a/ingress/rule.go
+++ b/ingress/rule.go
@@ -20,9 +20,9 @@ type Rule struct {
 	// Path is an optional regex that can specify path-driven ingress rules.
 	Path *Regexp `json:"path"`
 
-	// PathReplacement is an optional regexp replacement string for Path,
+	// Rewrite is an optional regexp replacement string for Path,
 	// that gets sent to the Service
-	PathReplacement string `json:"pathReplacement"`
+	Rewrite string `json:"rewrite"`
 
 	// A (probably local) address. Requests for a hostname which matches this
 	// rule's hostname pattern will be proxied to the service running on this

--- a/ingress/rule_test.go
+++ b/ingress/rule_test.go
@@ -194,25 +194,25 @@ func TestMarshalJSON(t *testing.T) {
 		{
 			name:     "Nil",
 			path:     nil,
-			expected: `{"hostname":"example.com","path":null,"pathReplacement":"","service":"https://localhost:8000","Handlers":null,"originRequest":{"connectTimeout":30,"tlsTimeout":10,"tcpKeepAlive":30,"noHappyEyeballs":false,"keepAliveTimeout":90,"keepAliveConnections":100,"httpHostHeader":"","originServerName":"","caPool":"","noTLSVerify":false,"disableChunkedEncoding":false,"bastionMode":false,"proxyAddress":"127.0.0.1","proxyPort":0,"proxyType":"","ipRules":null,"http2Origin":false,"access":{"teamName":"","audTag":null}}}`,
+			expected: `{"hostname":"example.com","path":null,"rewrite":"","service":"https://localhost:8000","Handlers":null,"originRequest":{"connectTimeout":30,"tlsTimeout":10,"tcpKeepAlive":30,"noHappyEyeballs":false,"keepAliveTimeout":90,"keepAliveConnections":100,"httpHostHeader":"","originServerName":"","caPool":"","noTLSVerify":false,"disableChunkedEncoding":false,"bastionMode":false,"proxyAddress":"127.0.0.1","proxyPort":0,"proxyType":"","ipRules":null,"http2Origin":false,"access":{"teamName":"","audTag":null}}}`,
 			want:     true,
 		},
 		{
 			name:     "Nil regex",
 			path:     &Regexp{Regexp: nil},
-			expected: `{"hostname":"example.com","path":null,"pathReplacement":"","service":"https://localhost:8000","Handlers":null,"originRequest":{"connectTimeout":30,"tlsTimeout":10,"tcpKeepAlive":30,"noHappyEyeballs":false,"keepAliveTimeout":90,"keepAliveConnections":100,"httpHostHeader":"","originServerName":"","caPool":"","noTLSVerify":false,"disableChunkedEncoding":false,"bastionMode":false,"proxyAddress":"127.0.0.1","proxyPort":0,"proxyType":"","ipRules":null,"http2Origin":false,"access":{"teamName":"","audTag":null}}}`,
+			expected: `{"hostname":"example.com","path":null,"rewrite":"","service":"https://localhost:8000","Handlers":null,"originRequest":{"connectTimeout":30,"tlsTimeout":10,"tcpKeepAlive":30,"noHappyEyeballs":false,"keepAliveTimeout":90,"keepAliveConnections":100,"httpHostHeader":"","originServerName":"","caPool":"","noTLSVerify":false,"disableChunkedEncoding":false,"bastionMode":false,"proxyAddress":"127.0.0.1","proxyPort":0,"proxyType":"","ipRules":null,"http2Origin":false,"access":{"teamName":"","audTag":null}}}`,
 			want:     true,
 		},
 		{
 			name:     "Empty",
 			path:     &Regexp{Regexp: regexp.MustCompile("")},
-			expected: `{"hostname":"example.com","path":"","pathReplacement":"","service":"https://localhost:8000","Handlers":null,"originRequest":{"connectTimeout":30,"tlsTimeout":10,"tcpKeepAlive":30,"noHappyEyeballs":false,"keepAliveTimeout":90,"keepAliveConnections":100,"httpHostHeader":"","originServerName":"","caPool":"","noTLSVerify":false,"disableChunkedEncoding":false,"bastionMode":false,"proxyAddress":"127.0.0.1","proxyPort":0,"proxyType":"","ipRules":null,"http2Origin":false,"access":{"teamName":"","audTag":null}}}`,
+			expected: `{"hostname":"example.com","path":"","rewrite":"","service":"https://localhost:8000","Handlers":null,"originRequest":{"connectTimeout":30,"tlsTimeout":10,"tcpKeepAlive":30,"noHappyEyeballs":false,"keepAliveTimeout":90,"keepAliveConnections":100,"httpHostHeader":"","originServerName":"","caPool":"","noTLSVerify":false,"disableChunkedEncoding":false,"bastionMode":false,"proxyAddress":"127.0.0.1","proxyPort":0,"proxyType":"","ipRules":null,"http2Origin":false,"access":{"teamName":"","audTag":null}}}`,
 			want:     true,
 		},
 		{
 			name:     "Basic",
 			path:     &Regexp{Regexp: regexp.MustCompile("/echo")},
-			expected: `{"hostname":"example.com","path":"/echo","pathReplacement":"","service":"https://localhost:8000","Handlers":null,"originRequest":{"connectTimeout":30,"tlsTimeout":10,"tcpKeepAlive":30,"noHappyEyeballs":false,"keepAliveTimeout":90,"keepAliveConnections":100,"httpHostHeader":"","originServerName":"","caPool":"","noTLSVerify":false,"disableChunkedEncoding":false,"bastionMode":false,"proxyAddress":"127.0.0.1","proxyPort":0,"proxyType":"","ipRules":null,"http2Origin":false,"access":{"teamName":"","audTag":null}}}`,
+			expected: `{"hostname":"example.com","path":"/echo","rewrite":"","service":"https://localhost:8000","Handlers":null,"originRequest":{"connectTimeout":30,"tlsTimeout":10,"tcpKeepAlive":30,"noHappyEyeballs":false,"keepAliveTimeout":90,"keepAliveConnections":100,"httpHostHeader":"","originServerName":"","caPool":"","noTLSVerify":false,"disableChunkedEncoding":false,"bastionMode":false,"proxyAddress":"127.0.0.1","proxyPort":0,"proxyType":"","ipRules":null,"http2Origin":false,"access":{"teamName":"","audTag":null}}}`,
 			want:     true,
 		},
 	}

--- a/ingress/rule_test.go
+++ b/ingress/rule_test.go
@@ -194,25 +194,25 @@ func TestMarshalJSON(t *testing.T) {
 		{
 			name:     "Nil",
 			path:     nil,
-			expected: `{"hostname":"example.com","path":null,"service":"https://localhost:8000","Handlers":null,"originRequest":{"connectTimeout":30,"tlsTimeout":10,"tcpKeepAlive":30,"noHappyEyeballs":false,"keepAliveTimeout":90,"keepAliveConnections":100,"httpHostHeader":"","originServerName":"","caPool":"","noTLSVerify":false,"disableChunkedEncoding":false,"bastionMode":false,"proxyAddress":"127.0.0.1","proxyPort":0,"proxyType":"","ipRules":null,"http2Origin":false,"access":{"teamName":"","audTag":null}}}`,
+			expected: `{"hostname":"example.com","path":null,"pathReplacement":"","service":"https://localhost:8000","Handlers":null,"originRequest":{"connectTimeout":30,"tlsTimeout":10,"tcpKeepAlive":30,"noHappyEyeballs":false,"keepAliveTimeout":90,"keepAliveConnections":100,"httpHostHeader":"","originServerName":"","caPool":"","noTLSVerify":false,"disableChunkedEncoding":false,"bastionMode":false,"proxyAddress":"127.0.0.1","proxyPort":0,"proxyType":"","ipRules":null,"http2Origin":false,"access":{"teamName":"","audTag":null}}}`,
 			want:     true,
 		},
 		{
 			name:     "Nil regex",
 			path:     &Regexp{Regexp: nil},
-			expected: `{"hostname":"example.com","path":null,"service":"https://localhost:8000","Handlers":null,"originRequest":{"connectTimeout":30,"tlsTimeout":10,"tcpKeepAlive":30,"noHappyEyeballs":false,"keepAliveTimeout":90,"keepAliveConnections":100,"httpHostHeader":"","originServerName":"","caPool":"","noTLSVerify":false,"disableChunkedEncoding":false,"bastionMode":false,"proxyAddress":"127.0.0.1","proxyPort":0,"proxyType":"","ipRules":null,"http2Origin":false,"access":{"teamName":"","audTag":null}}}`,
+			expected: `{"hostname":"example.com","path":null,"pathReplacement":"","service":"https://localhost:8000","Handlers":null,"originRequest":{"connectTimeout":30,"tlsTimeout":10,"tcpKeepAlive":30,"noHappyEyeballs":false,"keepAliveTimeout":90,"keepAliveConnections":100,"httpHostHeader":"","originServerName":"","caPool":"","noTLSVerify":false,"disableChunkedEncoding":false,"bastionMode":false,"proxyAddress":"127.0.0.1","proxyPort":0,"proxyType":"","ipRules":null,"http2Origin":false,"access":{"teamName":"","audTag":null}}}`,
 			want:     true,
 		},
 		{
 			name:     "Empty",
 			path:     &Regexp{Regexp: regexp.MustCompile("")},
-			expected: `{"hostname":"example.com","path":"","service":"https://localhost:8000","Handlers":null,"originRequest":{"connectTimeout":30,"tlsTimeout":10,"tcpKeepAlive":30,"noHappyEyeballs":false,"keepAliveTimeout":90,"keepAliveConnections":100,"httpHostHeader":"","originServerName":"","caPool":"","noTLSVerify":false,"disableChunkedEncoding":false,"bastionMode":false,"proxyAddress":"127.0.0.1","proxyPort":0,"proxyType":"","ipRules":null,"http2Origin":false,"access":{"teamName":"","audTag":null}}}`,
+			expected: `{"hostname":"example.com","path":"","pathReplacement":"","service":"https://localhost:8000","Handlers":null,"originRequest":{"connectTimeout":30,"tlsTimeout":10,"tcpKeepAlive":30,"noHappyEyeballs":false,"keepAliveTimeout":90,"keepAliveConnections":100,"httpHostHeader":"","originServerName":"","caPool":"","noTLSVerify":false,"disableChunkedEncoding":false,"bastionMode":false,"proxyAddress":"127.0.0.1","proxyPort":0,"proxyType":"","ipRules":null,"http2Origin":false,"access":{"teamName":"","audTag":null}}}`,
 			want:     true,
 		},
 		{
 			name:     "Basic",
 			path:     &Regexp{Regexp: regexp.MustCompile("/echo")},
-			expected: `{"hostname":"example.com","path":"/echo","service":"https://localhost:8000","Handlers":null,"originRequest":{"connectTimeout":30,"tlsTimeout":10,"tcpKeepAlive":30,"noHappyEyeballs":false,"keepAliveTimeout":90,"keepAliveConnections":100,"httpHostHeader":"","originServerName":"","caPool":"","noTLSVerify":false,"disableChunkedEncoding":false,"bastionMode":false,"proxyAddress":"127.0.0.1","proxyPort":0,"proxyType":"","ipRules":null,"http2Origin":false,"access":{"teamName":"","audTag":null}}}`,
+			expected: `{"hostname":"example.com","path":"/echo","pathReplacement":"","service":"https://localhost:8000","Handlers":null,"originRequest":{"connectTimeout":30,"tlsTimeout":10,"tcpKeepAlive":30,"noHappyEyeballs":false,"keepAliveTimeout":90,"keepAliveConnections":100,"httpHostHeader":"","originServerName":"","caPool":"","noTLSVerify":false,"disableChunkedEncoding":false,"bastionMode":false,"proxyAddress":"127.0.0.1","proxyPort":0,"proxyType":"","ipRules":null,"http2Origin":false,"access":{"teamName":"","audTag":null}}}`,
 			want:     true,
 		},
 	}

--- a/proxy/proxy_posix_test.go
+++ b/proxy/proxy_posix_test.go
@@ -46,9 +46,9 @@ func TestUnixSocketOrigin(t *testing.T) {
 
 	tests := []MultipleIngressTest{
 		{
-			url:            "http://unix.example.com",
+			url:            "http://unix.example.com/created",
 			expectedStatus: http.StatusCreated,
-			expectedBody:   []byte("Created"),
+			expectedBody:   []byte("/created"),
 		},
 	}
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -296,16 +296,22 @@ func TestProxyMultipleOrigins(t *testing.T) {
 
 	unvalidatedIngress := []config.UnvalidatedIngressRule{
 		{
-			Hostname:        "api.example.com",
-			Service:         api.URL,
-			Path:            "^/service1/(.*)$",
-			PathReplacement: "/$1",
+			Hostname: "api.example.com",
+			Service:  api.URL,
+			Path:     "^/service1/(.*)$",
+			Rewrite:  "/$1",
 		},
 		{
-			Hostname:        "api.example.com",
-			Service:         api.URL,
-			Path:            "^/service2/(.*)$",
-			PathReplacement: "/route2/$1",
+			Hostname: "api.example.com",
+			Service:  api.URL,
+			Path:     "^/service2/(.*)$",
+			Rewrite:  "/route2/$1",
+		},
+		{
+			Hostname: "api.example.com",
+			Service:  api.URL,
+			Path:     `^/service3/(.*)/(\w+)$`,
+			Rewrite:  "/$2/$1",
 		},
 		{
 			Hostname: "api.example.com",
@@ -336,6 +342,11 @@ func TestProxyMultipleOrigins(t *testing.T) {
 			url:            fmt.Sprintf("http://api.example.com/service2%s", hello.HealthRoute),
 			expectedStatus: http.StatusCreated,
 			expectedBody:   []byte(fmt.Sprintf("/route2%s", hello.HealthRoute)),
+		},
+		{
+			url:            fmt.Sprintf("http://api.example.com/service3/func%s", hello.HealthRoute),
+			expectedStatus: http.StatusCreated,
+			expectedBody:   []byte(fmt.Sprintf("%s/func", hello.HealthRoute)),
 		},
 		{
 			url:            "http://api.example.com/created",


### PR DESCRIPTION
This PR is inspired by https://github.com/cloudflare/cloudflared/compare/master...regnaio:regnaio/location from https://github.com/cloudflare/cloudflared/issues/563#issuecomment-1081779878.
It adds optional ingress.rule.rewrite parameter, which acts as a replacement string for ingress.rule.path regex.

Slightly modified example from the mentioned issue, which will work with this PR:
```yaml
  - hostname: subdomain.domain.com
    path: ^/subdir1/(.*)$
    service: https://localhost:3001
    rewrite: /$1
  - hostname: subdomain.domain.com
    path: ^/subdir2/(.*)$
    service: https://localhost:3002
    rewrite: /$1
  - hostname: subdomain.domain.com
    path: ^/subdir3/(.*)$
    service: https://localhost:3003
    rewrite: /$1
```

I'm not sure if there is a better way to do this, but reusing existing path regex sounds reasonable to me.
I'm also not sure how to better phrase the comment on ingress.Rule Rewrite.

Side effect from this PR: mockAPI now writes `r.URL.Path` instead of `"Created"` to the response body to test new changes.