### PR TITLE
Fix flaky tests

### DIFF
--- a/connection/h2mux_test.go
+++ b/connection/h2mux_test.go
@@ -119,7 +119,7 @@ func TestServeStreamHTTP(t *testing.T) {
 		} else {
 			assert.True(t, hasHeader(stream, ResponseMetaHeader, responseMetaHeaderOrigin))
 			body := make([]byte, len(test.expectedBody))
-			_, err = stream.Read(body)
+			_, err = io.ReadFull(stream, body)
 			require.NoError(t, err)
 			require.Equal(t, test.expectedBody, body)
 		}
@@ -264,7 +264,7 @@ func benchmarkServeStreamHTTPSimple(b *testing.B, test testRequest) {
 	for i := 0; i < b.N; i++ {
 		b.StartTimer()
 		stream, openstreamErr := edgeMux.OpenStream(ctx, headers, nil)
-		_, readBodyErr := stream.Read(body)
+		_, readBodyErr := io.ReadFull(stream, body)
 		b.StopTimer()
 
 		require.NoError(b, openstreamErr)

--- a/connection/http2_test.go
+++ b/connection/http2_test.go
@@ -497,7 +497,7 @@ func TestGracefulShutdownHTTP2(t *testing.T) {
 	case <-rpcClientFactory.registered:
 		break // ok
 	case <-time.Tick(time.Second):
-		t.Fatal("timeout out waiting for registration")
+		t.Fatal("timed out waiting for registration")
 	}
 
 	// signal graceful shutdown
@@ -507,12 +507,15 @@ func TestGracefulShutdownHTTP2(t *testing.T) {
 	case <-rpcClientFactory.unregistered:
 		break // ok
 	case <-time.Tick(time.Second):
-		t.Fatal("timeout out waiting for unregistered signal")
+		t.Fatal("timed out waiting for unregistered signal")
 	}
 	assert.True(t, controlStream.IsStopped())
 
 	cancel()
 	wg.Wait()
+
+	// give up CPU for a bit to let Observer.dispatchEvents propagate tunnel events
+	time.Sleep(300 * time.Millisecond)
 
 	events.assertSawEvent(t, Event{
 		Index:     http2Conn.connIndex,

--- a/connection/http2_test.go
+++ b/connection/http2_test.go
@@ -514,7 +514,7 @@ func TestGracefulShutdownHTTP2(t *testing.T) {
 	cancel()
 	wg.Wait()
 
-	// give up CPU for a bit to let Observer.dispatchEvents propagate tunnel events
+	// give up CPU for a bit to let Observer.dispatchEvents() propagate tunnel events
 	time.Sleep(300 * time.Millisecond)
 
 	events.assertSawEvent(t, Event{

--- a/connection/quic_test.go
+++ b/connection/quic_test.go
@@ -150,7 +150,7 @@ func TestQUICServer(t *testing.T) {
 			var serverReady sync.WaitGroup
 			serverReady.Add(1)
 
-			serverFinished := make(chan struct{}, 1)
+			serverFinished := make(chan struct{})
 			go func() {
 				defer cancel()
 				quicServer(
@@ -233,7 +233,7 @@ func quicServer(
 	// For now it is an echo server. Verify if the same data is returned.
 	assert.Equal(t, expectedResponse, response)
 
-	serverFinished <- struct{}{}
+	close(serverFinished)
 }
 
 type mockOriginProxyWithRequest struct{}

--- a/connection/quic_test.go
+++ b/connection/quic_test.go
@@ -226,7 +226,7 @@ func quicServer(
 	}
 
 	response := make([]byte, len(expectedResponse))
-	if _, err = stream.Read(response); err != io.EOF {
+	if _, err = io.ReadFull(stream, response); err != io.EOF {
 		require.NoError(t, err)
 	}
 

--- a/datagramsession/manager.go
+++ b/datagramsession/manager.go
@@ -2,6 +2,7 @@ package datagramsession
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -87,9 +88,10 @@ func (m *manager) shutdownSessions(err error) {
 	}
 	closeSessionErr := &errClosedSession{
 		message: err.Error(),
-		// Usually connection with remote has been closed, so set this to true to skip unregistering from remote
-		byRemote: true,
 	}
+	// Usually connection with remote has been closed, so set this to true to skip unregistering from remote
+	// context.Canceled is an exception because that means session is being closed by our side
+	closeSessionErr.byRemote = !errors.Is(err, context.Canceled)
 	for _, s := range m.sessions {
 		s.close(closeSessionErr)
 	}

--- a/datagramsession/manager.go
+++ b/datagramsession/manager.go
@@ -88,10 +88,10 @@ func (m *manager) shutdownSessions(err error) {
 	}
 	closeSessionErr := &errClosedSession{
 		message: err.Error(),
+		// Usually connection with remote has been closed, so set this to true to skip unregistering from remote
+		// context.Canceled is an exception because that means session is being closed by our side
+		byRemote: !errors.Is(err, context.Canceled),
 	}
-	// Usually connection with remote has been closed, so set this to true to skip unregistering from remote
-	// context.Canceled is an exception because that means session is being closed by our side
-	closeSessionErr.byRemote = !errors.Is(err, context.Canceled)
 	for _, s := range m.sessions {
 		s.close(closeSessionErr)
 	}

--- a/datagramsession/session_test.go
+++ b/datagramsession/session_test.go
@@ -111,8 +111,8 @@ func TestReadFromDstSessionPreventClosed(t *testing.T) {
 }
 
 func testActiveSessionNotClosed(t *testing.T, readFromDst bool, writeToDst bool) {
-	const closeAfterIdle = time.Millisecond * 100
-	const activeTime = time.Millisecond * 500
+	const closeAfterIdle = time.Millisecond * 300
+	const activeTime = closeAfterIdle * 3
 
 	sessionID := uuid.New()
 	cfdConn, originConn := net.Pipe()
@@ -129,7 +129,7 @@ func testActiveSessionNotClosed(t *testing.T, readFromDst bool, writeToDst bool)
 	errGroup, ctx := errgroup.WithContext(ctx)
 	errGroup.Go(func() error {
 		session.Serve(ctx, closeAfterIdle)
-		if time.Now().Before(startTime.Add(activeTime)) {
+		if time.Now().Before(activeUntil) {
 			return fmt.Errorf("session closed while it's still active")
 		}
 		return nil

--- a/h2mux/h2mux_test.go
+++ b/h2mux/h2mux_test.go
@@ -796,7 +796,7 @@ func TestMultipleStreamsWithDictionaries(t *testing.T) {
 
 				expectBody := strings.Replace(htmlBody, "paragraph", path, 1) + strconv.Itoa(index)
 				responseBody := make([]byte, len(expectBody)*2)
-				n, err := stream.Read(responseBody)
+				n, err := stream.Read(responseBody) // potentially flaky because of the partial read
 				if err != nil {
 					errorsC <- fmt.Errorf("stream %d error from (*MuxedStream).Read: %s", stream.streamID, err)
 					return

--- a/h2mux/h2mux_test.go
+++ b/h2mux/h2mux_test.go
@@ -977,7 +977,7 @@ func TestLongSiteWithDictionaries(t *testing.T) {
 
 		tstLen := 500
 		errGroup, _ := errgroup.WithContext(context.Background())
-		errGroup.SetLimit(runtime.NumGoroutine())
+		errGroup.SetLimit(runtime.GOMAXPROCS(0))
 		for i := 0; i < tstLen; i++ {
 			errGroup.Go(func() error {
 				path := paths[rand.Intn(len(paths))]

--- a/h2mux/h2mux_test.go
+++ b/h2mux/h2mux_test.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"net"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -976,9 +977,10 @@ func TestLongSiteWithDictionaries(t *testing.T) {
 
 		tstLen := 500
 		errGroup, _ := errgroup.WithContext(context.Background())
+		errGroup.SetLimit(runtime.NumGoroutine())
 		for i := 0; i < tstLen; i++ {
 			errGroup.Go(func() error {
-				path := paths[rand.Int()%len(paths)]
+				path := paths[rand.Intn(len(paths))]
 				return sampleSiteTest(muxPair, path, files)
 			})
 		}

--- a/orchestration/orchestrator_test.go
+++ b/orchestration/orchestrator_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -282,7 +281,7 @@ func TestConcurrentUpdateAndRead(t *testing.T) {
 			switch resp.StatusCode {
 			// v1 proxy, warp enabled
 			case 200:
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
 				require.Equal(t, t.Name(), string(body))
 				warpRoutingDisabled = false
@@ -504,7 +503,7 @@ func TestClosePreviousProxies(t *testing.T) {
 	require.Equal(t, http.StatusTeapot, resp.StatusCode)
 
 	// The hello-world server in config v1 should have been stopped. We wait a bit since it's closed asynchronously.
-	time.Sleep(time.Millisecond * 10)
+	time.Sleep(time.Millisecond * 300)
 	resp, err = proxyHTTP(originProxyV1, hostname)
 	require.Error(t, err)
 	require.Nil(t, resp)
@@ -522,8 +521,8 @@ func TestClosePreviousProxies(t *testing.T) {
 
 	// cancel the context should terminate the last proxy
 	cancel()
-	// Wait for proxies to shutdown
-	time.Sleep(time.Millisecond * 10)
+	// Wait for proxies to shut down
+	time.Sleep(time.Millisecond * 300)
 
 	resp, err = proxyHTTP(originProxyV3, hostname)
 	require.Error(t, err)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -465,10 +465,11 @@ func (r *replayer) Bytes() []byte {
 // eyeball sends tcp packets wrapped in websockets. (E.g: cloudflared access).
 func TestConnections(t *testing.T) {
 	logger := logger.Create(nil)
+	replayer := &replayer{rw: &bytes.Buffer{}}
 	type args struct {
 		ingressServiceScheme  string
 		originService         func(*testing.T, net.Listener)
-		eyeballResponseWriter func(io.Writer) connection.ResponseWriter
+		eyeballResponseWriter connection.ResponseWriter
 		eyeballRequestBody    io.ReadCloser
 
 		// Can be set to nil to show warp routing is not enabled.
@@ -495,13 +496,11 @@ func TestConnections(t *testing.T) {
 		{
 			name: "ws-ws proxy",
 			args: args{
-				ingressServiceScheme: "ws://",
-				originService:        runEchoWSService,
-				eyeballResponseWriter: func(w io.Writer) connection.ResponseWriter {
-					return newWSRespWriter(w)
-				},
-				eyeballRequestBody: newWSRequestBody([]byte("test1")),
-				connectionType:     connection.TypeWebsocket,
+				ingressServiceScheme:  "ws://",
+				originService:         runEchoWSService,
+				eyeballResponseWriter: newWSRespWriter(replayer),
+				eyeballRequestBody:    newWSRequestBody([]byte("test1")),
+				connectionType:        connection.TypeWebsocket,
 				requestHeaders: map[string][]string{
 					// Example key from https://tools.ietf.org/html/rfc6455#section-1.2
 					"Sec-Websocket-Key":     {"dGhlIHNhbXBsZSBub25jZQ=="},
@@ -521,14 +520,12 @@ func TestConnections(t *testing.T) {
 		{
 			name: "tcp-tcp proxy",
 			args: args{
-				ingressServiceScheme: "tcp://",
-				originService:        runEchoTCPService,
-				eyeballResponseWriter: func(w io.Writer) connection.ResponseWriter {
-					return newTCPRespWriter(w)
-				},
-				eyeballRequestBody: newTCPRequestBody([]byte("test2")),
-				warpRoutingService: ingress.NewWarpRoutingService(testWarpRouting),
-				connectionType:     connection.TypeTCP,
+				ingressServiceScheme:  "tcp://",
+				originService:         runEchoTCPService,
+				eyeballResponseWriter: newTCPRespWriter(replayer),
+				eyeballRequestBody:    newTCPRequestBody([]byte("test2")),
+				warpRoutingService:    ingress.NewWarpRoutingService(testWarpRouting),
+				connectionType:        connection.TypeTCP,
 				requestHeaders: map[string][]string{
 					"Cf-Cloudflared-Proxy-Src": {"non-blank-value"},
 				},
@@ -561,13 +558,11 @@ func TestConnections(t *testing.T) {
 		{
 			name: "ws-tcp proxy",
 			args: args{
-				ingressServiceScheme: "tcp://",
-				originService:        runEchoTCPService,
-				eyeballResponseWriter: func(w io.Writer) connection.ResponseWriter {
-					return newWSRespWriter(w)
-				},
-				eyeballRequestBody: newWSRequestBody([]byte("test4")),
-				connectionType:     connection.TypeWebsocket,
+				ingressServiceScheme:  "tcp://",
+				originService:         runEchoTCPService,
+				eyeballResponseWriter: newWSRespWriter(replayer),
+				eyeballRequestBody:    newWSRequestBody([]byte("test4")),
+				connectionType:        connection.TypeWebsocket,
 				requestHeaders: map[string][]string{
 					// Example key from https://tools.ietf.org/html/rfc6455#section-1.2
 					"Sec-Websocket-Key": {"dGhlIHNhbXBsZSBub25jZQ=="},
@@ -586,51 +581,45 @@ func TestConnections(t *testing.T) {
 			// Send (unexpected) HTTP when origin expects WS (to unwrap for raw TCP)
 			name: "http-(ws)tcp proxy",
 			args: args{
-				ingressServiceScheme: "tcp://",
-				originService:        runEchoTCPService,
-				eyeballResponseWriter: func(_ io.Writer) connection.ResponseWriter {
-					return newMockHTTPRespWriter()
-				},
-				eyeballRequestBody: http.NoBody,
-				connectionType:     connection.TypeHTTP,
+				ingressServiceScheme:  "tcp://",
+				originService:         runEchoTCPService,
+				eyeballResponseWriter: newMockHTTPRespWriter(),
+				eyeballRequestBody:    http.NoBody,
+				connectionType:        connection.TypeHTTP,
 				requestHeaders: map[string][]string{
 					"Cf-Cloudflared-Proxy-Src": {"non-blank-value"},
 				},
 			},
 			want: want{
-				message: nil,
+				message: []byte{},
 				headers: map[string][]string{},
 			},
 		},
 		{
 			name: "tcp-tcp proxy without warpRoutingService enabled",
 			args: args{
-				ingressServiceScheme: "tcp://",
-				originService:        runEchoTCPService,
-				eyeballResponseWriter: func(w io.Writer) connection.ResponseWriter {
-					return newTCPRespWriter(w)
-				},
-				eyeballRequestBody: newTCPRequestBody([]byte("test2")),
-				connectionType:     connection.TypeTCP,
+				ingressServiceScheme:  "tcp://",
+				originService:         runEchoTCPService,
+				eyeballResponseWriter: newTCPRespWriter(replayer),
+				eyeballRequestBody:    newTCPRequestBody([]byte("test2")),
+				connectionType:        connection.TypeTCP,
 				requestHeaders: map[string][]string{
 					"Cf-Cloudflared-Proxy-Src": {"non-blank-value"},
 				},
 			},
 			want: want{
-				message: nil,
+				message: []byte{},
 				err:     true,
 			},
 		},
 		{
 			name: "ws-ws proxy when origin is different",
 			args: args{
-				ingressServiceScheme: "ws://",
-				originService:        runEchoWSService,
-				eyeballResponseWriter: func(w io.Writer) connection.ResponseWriter {
-					return newWSRespWriter(w)
-				},
-				eyeballRequestBody: newWSRequestBody([]byte("test1")),
-				connectionType:     connection.TypeWebsocket,
+				ingressServiceScheme:  "ws://",
+				originService:         runEchoWSService,
+				eyeballResponseWriter: newWSRespWriter(replayer),
+				eyeballRequestBody:    newWSRequestBody([]byte("test1")),
+				connectionType:        connection.TypeWebsocket,
 				requestHeaders: map[string][]string{
 					// Example key from https://tools.ietf.org/html/rfc6455#section-1.2
 					"Sec-Websocket-Key": {"dGhlIHNhbXBsZSBub25jZQ=="},
@@ -656,17 +645,15 @@ func TestConnections(t *testing.T) {
 					// closing the listener created by the test.
 					ln.Close()
 				},
-				eyeballResponseWriter: func(w io.Writer) connection.ResponseWriter {
-					return newTCPRespWriter(w)
-				},
-				eyeballRequestBody: newTCPRequestBody([]byte("test2")),
-				connectionType:     connection.TypeTCP,
+				eyeballResponseWriter: newTCPRespWriter(replayer),
+				eyeballRequestBody:    newTCPRequestBody([]byte("test2")),
+				connectionType:        connection.TypeTCP,
 				requestHeaders: map[string][]string{
 					"Cf-Cloudflared-Proxy-Src": {"non-blank-value"},
 				},
 			},
 			want: want{
-				message: nil,
+				message: []byte{},
 				err:     true,
 			},
 		},
@@ -674,7 +661,6 @@ func TestConnections(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			replayer := &replayer{rw: &bytes.Buffer{}}
 			ctx, cancel := context.WithCancel(context.Background())
 			ln, err := net.Listen("tcp", "127.0.0.1:0")
 			require.NoError(t, err)
@@ -695,18 +681,15 @@ func TestConnections(t *testing.T) {
 			require.NoError(t, err)
 
 			req.Header = test.args.requestHeaders
+			respWriter := test.args.eyeballResponseWriter
 
-			var respWriter connection.ResponseWriter
 			if pipedReqBody, ok := test.args.eyeballRequestBody.(*pipedRequestBody); ok {
 				respWriter = newTCPRespWriter(pipedReqBody.pipedConn)
 				go func() {
 					resp := pipedReqBody.roundtrip(test.args.ingressServiceScheme + ln.Addr().String())
 					replayer.Write(resp)
 				}()
-			} else {
-				respWriter = test.args.eyeballResponseWriter(replayer)
 			}
-
 			if test.args.connectionType == connection.TypeTCP {
 				rwa := connection.NewHTTPResponseReadWriterAcker(respWriter, req)
 				err = proxy.ProxyTCP(ctx, rwa, &connection.TCPRequest{Dest: dest})

--- a/quic/datagram_test.go
+++ b/quic/datagram_test.go
@@ -189,7 +189,7 @@ func testDatagram(t *testing.T, version uint8, sessionToPayloads []*packet.Sessi
 		defer quicSession.CloseWithError(0, "")
 
 		// Wait a few milliseconds for MTU discovery to take place
-		time.Sleep(time.Millisecond * 100)
+		time.Sleep(time.Millisecond * 300)
 
 		var muxer BaseDatagramMuxer
 		switch version {

--- a/quic/quic_protocol.go
+++ b/quic/quic_protocol.go
@@ -205,7 +205,7 @@ func writeVersion(stream io.Writer) error {
 
 func readVersion(stream io.Reader) (string, error) {
 	version := make([]byte, protocolVersionLength)
-	_, err := stream.Read(version)
+	_, err := io.ReadFull(stream, version)
 	return string(version), err
 }
 

--- a/quic/safe_stream_test.go
+++ b/quic/safe_stream_test.go
@@ -124,7 +124,7 @@ func quicServer(t *testing.T, serverReady *sync.WaitGroup, conn net.PacketConn) 
 
 func clientRoundTrip(t *testing.T, stream io.ReadWriteCloser, mustWork bool) {
 	response := make([]byte, len(testMsg))
-	_, err := stream.Read(response)
+	_, err := io.ReadFull(stream, response)
 	if !mustWork {
 		return
 	}


### PR DESCRIPTION
This PR should potentially eliminate (or at least greatly reduce) `testActiveSessionNotClosed` flakiness at the Github CI.
As described in https://github.com/cloudflare/cloudflared/pull/766#issuecomment-1264874623, this is caused by an eager timeout due to insufficient CI CPU resources.

I didn't maintain the same ratio of `activeTime = closeAfterIdle * 5` as it'd make tests run ~50% longer while having potentially no difference in behavior besides running for a longer period of time.

Side effect: fixed datagramsession tests are now ~1.5s longer - 1.026s previously vs ~2.513s with this PR.

This PR also fixes race condition in `TestConnections` caused by concurrent read/write operations to shared variable `replayer` by newly created goroutines, which I got on CI after trying to fix the `testActiveSessionNotClosed`, CI logs are [here](https://github.com/moofMonkey/cloudflared/actions/runs/3173213348/jobs/5168571799#step:4:1523), Copy for the future reference is [here](https://gist.github.com/moofMonkey/ba619b823ec52bbd749071873e8451b3), as CI logs have limited lifetime.