### PR TITLE
Add hint why a quick tunnel isn't working if config.yaml is present

### DIFF
--- a/cmd/cloudflared/tunnel/cmd.go
+++ b/cmd/cloudflared/tunnel/cmd.go
@@ -170,7 +170,7 @@ func TunnelCommand(c *cli.Context) error {
 		return runAdhocNamedTunnel(sc, name, c.String(CredFileFlag))
 	}
 	if ref := config.GetConfiguration().TunnelID; ref != "" {
-		return fmt.Errorf("Use `cloudflared tunnel run` to start tunnel %s", ref)
+		return fmt.Errorf("Use `cloudflared tunnel run` to start tunnel %s. If you are trying to start a TryCloudflare quick tunnel, the `config.yaml` file must not be present (consider temporarily renaming it).", ref)
 	}
 
 	// Unauthenticated named tunnel on <random>.<quick-tunnels-service>.com


### PR DESCRIPTION
Since I just spent half an hour being confused why the documented `cloudflared tunnel --url http://localhost:8080` TryCloudflare quick tunnel would not work, I am proposing this hint be given to the user explaining the limitation and suggesting a workaround. I also added a couple sentences to the documentation to make note of this limitation:

https://github.com/cloudflare/cloudflare-docs/pull/6324

It would be better to eliminate the limitation entirely, I proposed how in that issue linked above.