### PR TITLE
Add suport for OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,8 @@ else ifeq ($(LOCAL_OS),windows)
     TARGET_OS ?= windows
 else ifeq ($(LOCAL_OS),freebsd)
     TARGET_OS ?= freebsd
+else ifeq ($(LOCAL_OS),openbsd)
+    TARGET_OS ?= openbsd
 else
     $(error This system's OS $(LOCAL_OS) isn't supported)
 endif


### PR DESCRIPTION
I've tested this on my OpenBSD 7.2 machine and this simple fix makes it compile and run flawlessly.