### PR TITLE
AUTH-4887 Add aud parameter to token transfer url

### DIFF
--- a/cmd/cloudflared/tunnel/login.go
+++ b/cmd/cloudflared/tunnel/login.go
@@ -52,6 +52,7 @@ func login(c *cli.Context) error {
 
 	resourceData, err := token.RunTransfer(
 		loginURL,
+		"",
 		"cert",
 		"callback",
 		callbackStoreURL,

--- a/token/token.go
+++ b/token/token.go
@@ -214,19 +214,19 @@ func getToken(appURL *url.URL, appInfo *AppInfo, useHostOnly bool, log *zerolog.
 			return appToken, nil
 		}
 	}
-	return getTokensFromEdge(appURL, appTokenPath, orgTokenPath, useHostOnly, log)
+	return getTokensFromEdge(appURL, appInfo.AppAUD, appTokenPath, orgTokenPath, useHostOnly, log)
 
 }
 
 // getTokensFromEdge will attempt to use the transfer service to retrieve an app and org token, save them to disk,
 // and return the app token.
-func getTokensFromEdge(appURL *url.URL, appTokenPath, orgTokenPath string, useHostOnly bool, log *zerolog.Logger) (string, error) {
+func getTokensFromEdge(appURL *url.URL, appAUD, appTokenPath, orgTokenPath string, useHostOnly bool, log *zerolog.Logger) (string, error) {
 	// If no org token exists or if it couldn't be exchanged for an app token, then run the transfer service flow.
 
 	// this weird parameter is the resource name (token) and the key/value
 	// we want to send to the transfer service. the key is token and the value
 	// is blank (basically just the id generated in the transfer service)
-	resourceData, err := RunTransfer(appURL, keyName, keyName, "", true, useHostOnly, log)
+	resourceData, err := RunTransfer(appURL, appAUD, keyName, keyName, "", true, useHostOnly, log)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to run transfer service")
 	}

--- a/token/transfer.go
+++ b/token/transfer.go
@@ -25,12 +25,12 @@ const (
 // The "dance" we refer to is building a HTTP request, opening that in a browser waiting for
 // the user to complete an action, while it long polls in the background waiting for an
 // action to be completed to download the resource.
-func RunTransfer(transferURL *url.URL, resourceName, key, value string, shouldEncrypt bool, useHostOnly bool, log *zerolog.Logger) ([]byte, error) {
+func RunTransfer(transferURL *url.URL, appAUD, resourceName, key, value string, shouldEncrypt bool, useHostOnly bool, log *zerolog.Logger) ([]byte, error) {
 	encrypterClient, err := NewEncrypter("cloudflared_priv.pem", "cloudflared_pub.pem")
 	if err != nil {
 		return nil, err
 	}
-	requestURL, err := buildRequestURL(transferURL, key, value+encrypterClient.PublicKey(), shouldEncrypt, useHostOnly)
+	requestURL, err := buildRequestURL(transferURL, appAUD, key, value+encrypterClient.PublicKey(), shouldEncrypt, useHostOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -76,9 +76,10 @@ func RunTransfer(transferURL *url.URL, resourceName, key, value string, shouldEn
 // BuildRequestURL creates a request suitable for a resource transfer.
 // it will return a constructed url based off the base url and query key/value provided.
 // cli will build a url for cli transfer request.
-func buildRequestURL(baseURL *url.URL, key, value string, cli, useHostOnly bool) (string, error) {
+func buildRequestURL(baseURL *url.URL, appAUD string, key, value string, cli, useHostOnly bool) (string, error) {
 	q := baseURL.Query()
 	q.Set(key, value)
+	q.Set("aud", appAUD)
 	baseURL.RawQuery = q.Encode()
 	if useHostOnly {
 		baseURL.Path = ""


### PR DESCRIPTION
This is an optional parameter that helps the /cdn-cgi/access/cli endpoint save some work figuring out which app it's doing the token transfer for. If not provided, it can figure that out on its own, like it currently does today.