### PR TITLE
ci/check: bump actions/checkout to v4, actions/setup-go to v5

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -13,6 +13,6 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Test
       run: make test


### PR DESCRIPTION
## Changes

- Bump `actions/checkout` from `v3` (Node 16) to `v4` (Node 20).
- Bump `actions/setup-go` from `v3` (Node 16) to `v5` (Node 20).