### PR TITLE
Update developerPortal URL in configuration.go

### DIFF
--- a/cmd/cloudflared/tunnel/configuration.go
+++ b/cmd/cloudflared/tunnel/configuration.go
@@ -33,9 +33,9 @@ import (
 const secretValue = "*****"
 
 var (
-	developerPortal = "https://developers.cloudflare.com/argo-tunnel"
-	serviceUrl      = developerPortal + "/reference/service/"
-	argumentsUrl    = developerPortal + "/reference/arguments/"
+	developerPortal = "https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup"
+	serviceUrl      = developerPortal + "/tunnel-guide/local/as-a-service/"
+	argumentsUrl    = developerPortal + "/tunnel-guide/local/local-management/arguments/"
 
 	secretFlags = [2]*altsrc.StringFlag{credentialsContentsFlag, tunnelTokenFlag}
 


### PR DESCRIPTION
Hello,

I would like to propose the following change in this pull request:

Update developerPortal URL in configuration.go: I have updated the developerPortal URL within the configuration.go file to point to the new correct location.
Additionally, I noticed an issue with the Cloudflare documentation redirect, which I wanted to bring to your attention. Here are the URLs in question:

Current URL:
https://developers.cloudflare.com/argo-tunnel/reference/service/
Incorrect redirect:
https://cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/local/as-a-service/
Correct URL:
https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-guide/local/as-a-service/

Please review my proposed changes and let me know if any further adjustments are required.
Thank you for your time and consideration.

Best regards,