### PR TITLE
Pass cloudflared_token_check param when running cloudflared access login

### DIFF
--- a/cmd/cloudflared/access/cmd.go
+++ b/cmd/cloudflared/access/cmd.go
@@ -525,6 +525,11 @@ func isTokenValid(options *carrier.StartOptions, log *zerolog.Logger) (bool, err
 		return false, errors.Wrap(err, "Could not create access request")
 	}
 	req.Header.Set("User-Agent", userAgent)
+
+	query := req.URL.Query()
+	query.Set("cloudflared_token_check", "true")
+	req.URL.RawQuery = query.Encode()
+
 	// Do not follow redirects
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {


### PR DESCRIPTION
The back-end is already set to handle this query arg. This fixes timeouts validating access tokens if the origin is not ready to handle the http request.

Internal tracking ticket: AUTH-5328