### PR TITLE
Run checks with Go 1.20

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,7 +4,7 @@ jobs:
   check:
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.20.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Go 1.19 is unmaintained since Go 1.21 was released.

Go 1.20 compatibility was added since v2023.5.1 via [TUN-7227: Migrate to devincarr/quic-go](https://github.com/cloudflare/cloudflared/commit/9426b603082905d0af8a07bdac866bc1d9c37cba)

See also 
* #1047
* #888 
* a more thorough replacement PR: #1052
* needs further work for Go 1.21: #1043