### PR TITLE
[access] use os.Executable to discover the path to cloudflared when generating ssh config

### DIFF
--- a/cmd/cloudflared/access/cmd.go
+++ b/cmd/cloudflared/access/cmd.go
@@ -466,6 +466,11 @@ func processURL(s string) (*url.URL, error) {
 
 // cloudflaredPath pulls the full path of cloudflared on disk
 func cloudflaredPath() string {
+	path, err := os.Executable()
+	if err == nil && isFileThere(path) {
+		return path
+	}
+
 	for _, p := range strings.Split(os.Getenv("PATH"), ":") {
 		path := fmt.Sprintf("%s/%s", p, "cloudflared")
 		if isFileThere(path) {


### PR DESCRIPTION
Uses os.Executable to discover the path to cloudflared when generating ssh config. If os.Executable is unavailable, falls back to the previous method.

This allows for more accurate generation of the ssh config. Previously, if cloudflared was installed in the PATH, an incorrect config could be generated. This also allows for inclusion of the subcommand in other `cli/v2` apps that are not named `cloudflared`.

<img width="1059" alt="image" src="https://github.com/cloudflare/cloudflared/assets/553597/1f9b35d2-d2af-45ab-b773-ab62e54afe52">
