### PR TITLE
Build with still supported Go 1.20

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,7 +4,7 @@ jobs:
   check:
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.20.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # use a builder image for building cloudflare
 ARG TARGET_GOOS
 ARG TARGET_GOARCH
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 ENV GO111MODULE=on \
     CGO_ENABLED=0 \
     TARGET_GOOS=${TARGET_GOOS} \

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,5 +1,5 @@
 # use a builder image for building cloudflare
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 ENV GO111MODULE=on \
     CGO_ENABLED=0 
     

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,5 +1,5 @@
 # use a builder image for building cloudflare
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 ENV GO111MODULE=on \
     CGO_ENABLED=0 
     

--- a/cfsetup.yaml
+++ b/cfsetup.yaml
@@ -1,5 +1,5 @@
-pinned_go: &pinned_go go=1.19.6-1
-pinned_go_fips: &pinned_go_fips go-boring=1.19.6-1
+pinned_go: &pinned_go go=1.20.7-1
+pinned_go_fips: &pinned_go_fips go-boring=1.20.7-1
 
 build_dir: &build_dir /cfsetup_build
 default-flavor: bullseye

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 ENV GO111MODULE=on \
     CGO_ENABLED=0
 WORKDIR /go/src/github.com/cloudflare/cloudflared/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudflare/cloudflared
 
-go 1.19
+go 1.20
 
 require (
 	github.com/cloudflare/brotli-go v0.0.0-20191101163834-d34379f7ff93


### PR DESCRIPTION
Minimal changes to migrate everything from unsupported Go 1.19 to 1.20

Go 1.20 compatibility was fixed since v2023.5.1 via [TUN-7227: Migrate to devincarr/quic-go](https://github.com/cloudflare/cloudflared/commit/9426b603082905d0af8a07bdac866bc1d9c37cba)

Related issues & PRs:
* Fixes #1047
* Closes #1027 (that one just bumps running checks to Go 1.20 and 0e0c286 is included in this PR )
* Further work will be needed to support Go 1.21: #1043