### PR TITLE
cmd/cloudflared/updater: fix dropped error

### DIFF
--- a/cmd/cloudflared/updater/workers_service.go
+++ b/cmd/cloudflared/updater/workers_service.go
@@ -56,6 +56,9 @@ func (s *WorkersService) Check() (CheckResult, error) {
 	}
 
 	req, err := http.NewRequest(http.MethodGet, s.url, nil)
+	if err != nil {
+		return nil, err
+	}
 	q := req.URL.Query()
 	q.Add(OSKeyName, runtime.GOOS)
 	q.Add(ArchitectureKeyName, runtime.GOARCH)


### PR DESCRIPTION
This picks up a dropped `err` variable in `cmd/cloudflared/updater`.