### PR TITLE
Nil pointer dereference panic when passing "null" config json to `cloudflared tunnel ingress validate`

### DIFF
--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -85,7 +85,7 @@ type Ingress struct {
 
 // ParseIngress parses ingress rules, but does not send HTTP requests to the origins.
 func ParseIngress(conf *config.Configuration) (Ingress, error) {
-	if len(conf.Ingress) == 0 {
+	if conf == nil || len(conf.Ingress) == 0 {
 		return Ingress{}, ErrNoIngressRules
 	}
 	return validateIngress(conf.Ingress, originRequestFromConfig(conf.OriginRequest))

--- a/ingress/ingress_test.go
+++ b/ingress/ingress_test.go
@@ -43,6 +43,11 @@ ingress:
 	require.Equal(t, "https", s.scheme)
 }
 
+func TestParseIngressNilConfig(t *testing.T) {
+	_, err := ParseIngress(nil)
+	require.Error(t, err)
+}
+
 func TestParseIngress(t *testing.T) {
 	localhost8000 := MustParseURL(t, "https://localhost:8000")
 	localhost8001 := MustParseURL(t, "https://localhost:8001")


### PR DESCRIPTION
Hi

Calling `cloudflared tunnel ingress validate --json "null"` causes the `cloudflared` process to crash with the following error:

```
# ./cloudflared tunnel ingress validate --json "null"
Validating rules from cmdline flag --json
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xf154b3]

goroutine 1 [running]:
github.com/cloudflare/cloudflared/ingress.ParseIngress(_)
        /workspaces/cloudflared/ingress/ingress.go:88 +0x53
github.com/cloudflare/cloudflared/cmd/cloudflared/tunnel.validateIngressCommand(0x7cda9c?, {0x0, 0x0})
        /workspaces/cloudflared/cmd/cloudflared/tunnel/ingress_subcommands.go:88 +0x78
github.com/cloudflare/cloudflared/cmd/cloudflared/cliutil.ConfiguredActionWithWarnings.func1(0xc00061dba8?)
        /workspaces/cloudflared/cmd/cloudflared/cliutil/handler.go:31 +0x51
github.com/cloudflare/cloudflared/cmd/cloudflared/cliutil.WithErrorHandler.func1(0xc000645cc0)
        /workspaces/cloudflared/cmd/cloudflared/cliutil/errors.go:27 +0x37
github.com/urfave/cli/v2.(*Command).Run(0xc0002b7b00, 0xc000645b80)
        /workspaces/cloudflared/vendor/github.com/urfave/cli/v2/command.go:163 +0x476
github.com/urfave/cli/v2.(*App).RunAsSubcommand(0xc000284b60, 0xc000645ac0)
        /workspaces/cloudflared/vendor/github.com/urfave/cli/v2/app.go:434 +0xb36
github.com/urfave/cli/v2.(*Command).startApp(0xc0002b7d40, 0xc000645ac0)
        /workspaces/cloudflared/vendor/github.com/urfave/cli/v2/command.go:279 +0x753
github.com/urfave/cli/v2.(*Command).Run(0xc0005faa80?, 0x59?)
        /workspaces/cloudflared/vendor/github.com/urfave/cli/v2/command.go:94 +0xaa
github.com/urfave/cli/v2.(*App).RunAsSubcommand(0xc000284820, 0xc000644100)
        /workspaces/cloudflared/vendor/github.com/urfave/cli/v2/app.go:434 +0xb36
github.com/urfave/cli/v2.(*Command).startApp(0xc000626480, 0xc000644100)
        /workspaces/cloudflared/vendor/github.com/urfave/cli/v2/command.go:279 +0x753
github.com/urfave/cli/v2.(*Command).Run(0xc0005fa000?, 0x5a?)
        /workspaces/cloudflared/vendor/github.com/urfave/cli/v2/command.go:94 +0xaa
github.com/urfave/cli/v2.(*App).RunContext(0xc0002844e0, {0x13e5f28?, 0xc0000c4000}, {0xc0000ca120, 0x6, 0x6})
        /workspaces/cloudflared/vendor/github.com/urfave/cli/v2/app.go:313 +0x9c7
github.com/urfave/cli/v2.(*App).Run(...)
        /workspaces/cloudflared/vendor/github.com/urfave/cli/v2/app.go:224
main.runApp(0xc0002844e0, 0xe?)
        /workspaces/cloudflared/cmd/cloudflared/linux_service.go:38 +0x2e5
main.main()
        /workspaces/cloudflared/cmd/cloudflared/main.go:94 +0x96b
```

The same error is also able to be triggered through the Cloudflare REST API:

```http
PUT https://api.cloudflare.com/client/v4/accounts/{{accountId}}/cfd_tunnel/{{tunnelId}}/configurations
{
    "config": null
}
```

```json
{
    "success": false,
    "errors": [
        {
            "code": 1056,
            "message": "Bad Configuration: panic: runtime error: invalid memory address or nil pointer dereference\n[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xf0ab73]\n\ngoroutine 1 [running]:\ngithub.com/cloudflare/cloudflared/ingress.ParseIngress(_)\n\t/cfsetup_build/ingress/ingress.go:88 ..."
        }
    ],
    "messages": [],
    "result": null
}
```

This PR adds a `nil` check to the configuration in `ParseIngress`.