### PR TITLE
GH-843: Add option to disable remote configuration

### DIFF
--- a/cmd/cloudflared/tunnel/cmd.go
+++ b/cmd/cloudflared/tunnel/cmd.go
@@ -782,6 +782,12 @@ func tunnelFlags(shouldHide bool) []cli.Flag {
 			EnvVars: []string{"TUNNEL_MANAGEMENT_DIAGNOSTICS"},
 			Value:   false,
 		}),
+		altsrc.NewBoolFlag(&cli.BoolFlag{
+			Name:    config.DisableRemoteConfigFlag,
+			Usage:   "Disables remote configuration from the edge",
+			EnvVars: []string{"TUNNEL_NO_REMOTE_CONFIG"},
+			Value:   false,
+		}),
 		selectProtocolFlag,
 		overwriteDNSFlag,
 	}...)

--- a/cmd/cloudflared/tunnel/configuration.go
+++ b/cmd/cloudflared/tunnel/configuration.go
@@ -39,7 +39,7 @@ var (
 
 	secretFlags = [2]*altsrc.StringFlag{credentialsContentsFlag, tunnelTokenFlag}
 
-	configFlags = []string{"autoupdate-freq", "no-autoupdate", "retries", "protocol", "loglevel", "transport-loglevel", "origincert", "metrics", "metrics-update-freq", "edge-ip-version", "edge-bind-address"}
+	configFlags = []string{"autoupdate-freq", "no-autoupdate", "retries", "protocol", "loglevel", "transport-loglevel", "origincert", "metrics", "metrics-update-freq", "edge-ip-version", "edge-bind-address", config.DisableRemoteConfigFlag}
 )
 
 func generateRandomClientID(log *zerolog.Logger) (string, error) {
@@ -135,6 +135,15 @@ func prepareTunnelConfig(
 	transportProtocol := c.String("protocol")
 
 	clientFeatures := features.Dedup(append(c.StringSlice("features"), features.DefaultFeatures...))
+	if c.Bool(config.DisableRemoteConfigFlag) {
+		log.Info().Msg("Remote configuration disabled")
+		for i, feature := range clientFeatures {
+			if feature == features.FeatureAllowRemoteConfig {
+				clientFeatures = append(clientFeatures[:i], clientFeatures[i+1:]...)
+				break
+			}
+		}
+	}
 
 	staticFeatures := features.StaticFeatures{}
 	if c.Bool("post-quantum") {

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -41,6 +41,9 @@ var (
 const (
 	// BastionFlag is to enable bastion, or jump host, operation
 	BastionFlag = "bastion"
+
+	// DisableRemoteConfigFlag is to disable remote configuration
+	DisableRemoteConfigFlag = "no-remote-config"
 )
 
 // DefaultConfigDirectory returns the default directory of the config file


### PR DESCRIPTION
Implements #843 

- Add a new `--no-remote-config` global CLI option
- When the option is enabled:
    - Stop advertising `FeatureAllowRemoteConfig` in the `clientFeatures` passed to `tunnelpogs`
    - Ignore incoming remote config updates in `Orchestrator`

`cloudflared` seemed to behave correctly while testing locally:
- On a migrated remotely-managed Tunnel, config from the Zero Trust dashboard was ignored, both at startup and when updating it, while the local config kept being enforced
- Migrating an established locally-managed Tunnel to remote management doesn't disturb it, traffic continues to flow as if nothing had happened

For better UX, Cloudflare could implement an additional requirement on the ZT dashboard when `--no-remote-config` is enabled to prevent migration from local to remote management, or more generally a warning banner on the Tunnel configuration page (the option already gets displayed in the UI so I'd guess it's a small change).

Not a Gopher, advice is very welcome!