### PR TITLE
Added a optional functionality for sending email to a recipient every time a new quick tunnel is created, i.e. sending a email the URL of the quick tunnel that is created.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,57 @@
-# Cloudflare Tunnel client
+# How to use This fork 
 
-Contains the command-line client for Cloudflare Tunnel, a tunneling daemon that proxies traffic from the Cloudflare network to your origins.
+## Compiling `cloudflared-notify` from source
+
+- To compile this project you need to have ```build-essential(for debian)```/```base-devel(for arch)```/```OR euivalent package for your distro``` and ```go``` and ```python``` installed  in your system.
++ Clone or download this repo into your machine and go inside the ***cloudflared-notify*** folder & open a terminal in this folder location and type ```make cloudflared```, if successful then this will create a executable named **```cloudflared```**.
+* This cloudflared executable can now be used as you would normally use the cloudflared executable.
+
+> [!Note]
+> Please note this fork is the same as normal cloudflare-tunnel, you need not to use another cloudflare-tunnel app if you are using this fork
+
+
+## Using `cloudflared-notify`
+
+#### It uses gmail smtp for sending out mail as for now, other mail services will be added in future (Mention your suggested mail server if any by opening an issue)
+
+- To use this forked version of cloudflare tunnel notification functionality, you need to have a gmail account.
+
++ Now create an app password for your gmail account, [read instructions here on how to create app password](https://support.google.com/accounts/answer/185833?hl=en)
+
+* Finally to take advantage of this notification functionality, run the cloudflared executable with this following commandline arguments:
+
+
+```sh
+cloudflared tunnel --url http://localhost:6009 --notify receipeint@mailID --uname login@mailID --key 16-digit-app-password-for-login@mailID
+```
+
+
+## Why this fork
+This specific fork is for you if you are like me and is too poor to buy a domain *\*just kidding I know you make six-figures yearly ;)\**.
+<br>
+*(I know about freenom, but as for now freenom is not allowing to register new free domains 🤧🤧🤧🤧🤧)*
+<br>
+<br>
+Let's consider my use case, my ISP charges a huge sum of money monthly for static IP, which is not feasable for me as a student, also my home server goes whereever I go, thats why static IP is of no use for me.
+<br>
+<br>
+Then I stumpled upon **cloudflared**, \*my dream come true scenerio\*, but then comes the problem of buying & adding a domain in cloudflare if I want the url to be persistent and known to me, which is also not feasible for me *(because why pay money when you know how to reverse engineer & edit opensource code 😎😎 \*wallet sadness intensifies\*)* 
+<br>
+<br>
+So I finalized the decision of using cloudflare quick tunnels, but the link reset every time my cloudflared service restarts.
+<br>
+And to know the new link every time the cloudflared service restarts I make this fork, that notifies the user via email the newly created quick tunnel link.
+<br>
+<br>
+Now I dont need to physically go into my home server and fetch the quick tunnel link every time the cloudflared service restarts, I just get the link delivered in my mail box like a nerd 😎😎.
+<br>
+<br>
+**I hope, you as user find this feature useful, and a huge credit goes to the team behind cloudflare-tunnel for making the cloudflared project opensource and letting developers like us in making the software better for every taste.**
+
+
+# Cloudflared-notify Tunnel client
+
+Contains the forked command-line client for Cloudflare Tunnel, a tunneling daemon that proxies traffic from the Cloudflare network to your origins.
 This daemon sits between Cloudflare network and your origin (e.g. a webserver). Cloudflare attracts client requests and sends them to you
 via this daemon, without requiring you to poke holes on your firewall --- your origin can remain as closed as possible.
 Extensive documentation can be found in the [Cloudflare Tunnel section](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps) of the Cloudflare Docs.
@@ -12,7 +63,6 @@ Such usages are available under `cloudflared access help`.
 
 You can instead use [WARP client](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configuration/private-networks)
 to access private origins behind Tunnels for Layer 4 traffic without requiring `cloudflared access` commands on the client side.
-
 
 ## Before you get started
 

--- a/cmd/cloudflared/tunnel/cmd.go
+++ b/cmd/cloudflared/tunnel/cmd.go
@@ -213,7 +213,7 @@ func TunnelCommand(c *cli.Context) error {
 	// We don't support running proxy-dns and a quick tunnel at the same time as the same process
 	shouldRunQuickTunnel := c.IsSet("url") || c.IsSet(ingress.HelloWorldFlag)
 	if !c.IsSet("proxy-dns") && c.String("quick-service") != "" && shouldRunQuickTunnel {
-		return RunQuickTunnel(sc)
+		return RunQuickTunnel(sc, c)
 	}
 
 	// If user provides a config, check to see if they meant to use `tunnel run` instead
@@ -842,6 +842,21 @@ func configureProxyFlags(shouldHide bool) []cli.Flag {
 			Usage:   "Connect to the local webserver at `URL`.",
 			EnvVars: []string{"TUNNEL_URL"},
 			Hidden:  shouldHide,
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:   "notify",
+			Usage:  "Email address of the recipient to whom to send the quick tunnel URL notification.",
+			Hidden: shouldHide,
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:   "uname",
+			Usage:  "Username/Email-id of the mail account to authenticate the SMTP server.",
+			Hidden: shouldHide,
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:   "key",
+			Usage:  "Password/key of the mail account to authenticate the SMTP server.",
+			Hidden: shouldHide,
 		}),
 		altsrc.NewBoolFlag(&cli.BoolFlag{
 			Name:    ingress.HelloWorldFlag,

--- a/cmd/cloudflared/tunnel/quick_tunnel.go
+++ b/cmd/cloudflared/tunnel/quick_tunnel.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/smtp"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
 
 	"github.com/cloudflare/cloudflared/connection"
 )
@@ -20,10 +22,33 @@ const disclaimer = "Thank you for trying Cloudflare Tunnel. Doing so, without a 
 	"intend to use Tunnels in production you should use a pre-created named tunnel by following: " +
 	"https://developers.cloudflare.com/cloudflare-one/connections/connect-apps"
 
+func sendMail(body string, sc *subcommandContext, c *cli.Context) int {
+	from := c.String("uname")
+	pass := c.String("key")
+	to := c.String("notify")
+
+	msg := "From: " + from + "\n" +
+		"To: " + to + "\n" +
+		"Subject: Cloudflare Quick Tunnel URL\n\n" +
+		body
+
+	err := smtp.SendMail("smtp.gmail.com:587",
+		smtp.PlainAuth("", from, pass, "smtp.gmail.com"),
+		from, []string{to}, []byte(msg))
+
+	if err != nil {
+		sc.log.Err(err).Msg("smtp error : Failed to send email")
+		return 1
+	}
+
+	sc.log.Info().Msg("Email notification sent successfully to " + c.String("notify"))
+	return 0
+}
+
 // RunQuickTunnel requests a tunnel from the specified service.
 // We use this to power quick tunnels on trycloudflare.com, but the
 // service is open-source and could be used by anyone.
-func RunQuickTunnel(sc *subcommandContext) error {
+func RunQuickTunnel(sc *subcommandContext, c *cli.Context) error {
 	sc.log.Info().Msg(disclaimer)
 	sc.log.Info().Msg("Requesting new quick Tunnel on trycloudflare.com...")
 
@@ -67,6 +92,22 @@ func RunQuickTunnel(sc *subcommandContext) error {
 		url,
 	}, 2) {
 		sc.log.Info().Msg(line)
+	}
+
+	if c.IsSet("notify") && c.IsSet("uname") && c.IsSet("key") {
+		sendMail(url, sc, c)
+	} else {
+		if !c.IsSet("uname") {
+			sc.log.Error().Msg("smtp error : Failed to send email. err(): --uname SMTP login username not specified")
+		}
+
+		if !c.IsSet("key") {
+			sc.log.Error().Msg("smtp error : Failed to send email. err(): --key SMTP login password not specified")
+		}
+
+		if !c.IsSet("notify") {
+			sc.log.Error().Msg("smtp error : Failed to send email. err(): --notify No recipient mail address specified")
+		}
 	}
 
 	if !sc.c.IsSet("protocol") {

--- a/cmd/cloudflared/tunnel/quick_tunnel.go
+++ b/cmd/cloudflared/tunnel/quick_tunnel.go
@@ -49,6 +49,11 @@ func sendMail(body string, sc *subcommandContext, c *cli.Context) int {
 // We use this to power quick tunnels on trycloudflare.com, but the
 // service is open-source and could be used by anyone.
 func RunQuickTunnel(sc *subcommandContext, c *cli.Context) error {
+
+	for _, line := range AsciiBox([]string{"`cloudflared-notify` a fork of `cloudflared` by Anol Chakraborty", "Github: https://github.com/AnolChakraborty/cloudflared-notify"}, 2) {
+		sc.log.Info().Msg(line)
+	}
+
 	sc.log.Info().Msg(disclaimer)
 	sc.log.Info().Msg("Requesting new quick Tunnel on trycloudflare.com...")
 


### PR DESCRIPTION
## Why this added functionality ?
This added optional functionality is for you if you are like me and is too poor to buy a domain *\*just kidding I know you make six-figures yearly ;)\**.
<br>
*(I know about freenom, but as for now freenom is not allowing to register new free domains 🤧🤧🤧🤧🤧)*
<br>
Let's consider my use case, my ISP charges a huge sum of money monthly for static IP, which is not feasable for me as a student, also my home server goes whereever I go, thats why static IP is of no use for me.
<br>
Then I stumpled upon **cloudflared**, \*my dream come true scenerio\*, but then comes the problem of buying & adding a domain in cloudflare if I want the tunnel URL to be persistent and known to me, which is also not feasible for me *(because why pay money when you know how to reverse engineer & edit opensource code 😎😎 \*wallet sadness intensifies\*)* 
<br>
So I finalized the decision of using cloudflare quick tunnels, but the link reset every time my cloudflared service restarts.
<br>
And to know the new link every time the cloudflared service restarts I make this change, that notifies the user via email the newly created quick tunnel link.
<br>
Now the user don't need to physically go into the system and fetch the quick tunnel link every time the cloudflared service restarts, you just get the link delivered to your mail box like a nerd 😎😎.
<br>
**I hope, you find this feature useful**


## Using cloudflared notification

#### It uses gmail smtp for sending out mail as for now, other mail services will/can be added in future

- To use this feature of notification functionality, you need to have a gmail account.

+ Now create an app password for your gmail account, [read instructions here on how to create app password](https://support.google.com/accounts/answer/185833?hl=en)

* Finally to take advantage of this notification functionality, run the cloudflared executable with this following command line arguments:


```sh
cloudflared tunnel --url http://localhost:8080 --notify receipeint@mailID --uname login@mailID --key 16-digit-app-password-for-login@mailID
```


**Tested on my Arch system (I use arch btw ;) ), it compiles (```make cloudflared```) & runs with no problem**