### PR TITLE
Added the functionality for sending email to a recipient every time a new quick tunnel is created, i.e. sending the URL of the created quick tunnel via email to the recipient.

### DIFF
--- a/cmd/cloudflared/tunnel/cmd.go
+++ b/cmd/cloudflared/tunnel/cmd.go
@@ -213,7 +213,7 @@ func TunnelCommand(c *cli.Context) error {
 	// We don't support running proxy-dns and a quick tunnel at the same time as the same process
 	shouldRunQuickTunnel := c.IsSet("url") || c.IsSet(ingress.HelloWorldFlag)
 	if !c.IsSet("proxy-dns") && c.String("quick-service") != "" && shouldRunQuickTunnel {
-		return RunQuickTunnel(sc)
+		return RunQuickTunnel(sc, c)
 	}
 
 	// If user provides a config, check to see if they meant to use `tunnel run` instead
@@ -842,6 +842,21 @@ func configureProxyFlags(shouldHide bool) []cli.Flag {
 			Usage:   "Connect to the local webserver at `URL`.",
 			EnvVars: []string{"TUNNEL_URL"},
 			Hidden:  shouldHide,
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:   "notify",
+			Usage:  "Email address of the recipient to whom to send the quick tunnel URL notification.",
+			Hidden: shouldHide,
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:   "uname",
+			Usage:  "Username/Email-id of the mail account to authenticate the SMTP server.",
+			Hidden: shouldHide,
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:   "key",
+			Usage:  "Password/key of the mail account to authenticate the SMTP server.",
+			Hidden: shouldHide,
 		}),
 		altsrc.NewBoolFlag(&cli.BoolFlag{
 			Name:    ingress.HelloWorldFlag,


### PR DESCRIPTION
## Why this added functionality ?
This added optional functionality is for you if you are like me and is too poor to buy a domain *\*just kidding I know you make six-figures yearly ;)\**.
<br>
*(I know about freenom, but as for now freenom is not allowing to register new free domains 🤧🤧🤧🤧🤧)*
<br>
Let's consider my use case, my ISP charges a huge sum of money monthly for static IP, which is not feasable for me as a student, also my home server goes whereever I go, thats why static IP is of no use for me.
<br>
Then I stumpled upon **cloudflared**, \*my dream come true scenerio\*, but then comes the problem of buying & adding a domain in cloudflare if I want the tunnel URL to be persistent and known to me, which is also not feasible for me *(because why pay money when you know how to reverse engineer & edit opensource code 😎😎 \*wallet sadness intensifies\*)*
<br>
So I finalized the decision of using cloudflare quick tunnels, but the link reset every time my cloudflared service restarts.
<br>
And to know the new link every time the cloudflared service restarts I make this change, that notifies the user via email the newly created quick tunnel link.
<br>
Now the user don't need to physically go into the system and fetch the quick tunnel link every time the cloudflared service restarts, you just get the link delivered to your mail box like a nerd 😎😎.
<br>
**I hope, you find this feature useful**


## Using cloudflared notification

#### It uses gmail smtp for sending out mail as for now, other mail services will/can be added in future

- To use this feature of notification functionality, you need to have a gmail account.

+ Now create an app password for your gmail account, [read instructions here on how to create app password](https://support.google.com/accounts/answer/185833?hl=en)

* Finally to take advantage of this notification functionality, run the cloudflared executable with this following command line arguments:


```sh
cloudflared tunnel --url http://localhost:6009 --notify receipeint@mailID --uname login@mailID --key 16-digit-app-password-for-login@mailID
```


**Tested on my Arch system (I use arch btw ;) ), it compiles (```make cloudflared```) & runs with no problem**
