### PR TITLE
tunnelrpc/pogs: fix dropped test errors

### DIFF
--- a/tunnelrpc/pogs/auth_test.go
+++ b/tunnelrpc/pogs/auth_test.go
@@ -118,6 +118,7 @@ func TestSerializeAuthenticationResponse(t *testing.T) {
 
 	for i, testCase := range tests {
 		_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
+		assert.NoError(t, err)
 		capnpEntity, err := tunnelrpc.NewAuthenticateResponse(seg)
 		if !assert.NoError(t, err) {
 			t.Fatal("Couldn't initialize a new message")

--- a/tunnelrpc/pogs/tunnelrpc_test.go
+++ b/tunnelrpc/pogs/tunnelrpc_test.go
@@ -38,6 +38,7 @@ func TestTunnelRegistration(t *testing.T) {
 	}
 	for i, testCase := range testCases {
 		_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
+		assert.NoError(t, err)
 		capnpEntity, err := tunnelrpc.NewTunnelRegistration(seg)
 		if !assert.NoError(t, err) {
 			t.Fatal("Couldn't initialize a new message")


### PR DESCRIPTION
This picks up two dropped test `err` variables in `tunnelrpc/pogs`.