### PR TITLE
Added FreeBSD builds

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -38,3 +38,12 @@ for arch in ${linuxArchs[@]}; do
     # finally move the linux binary as well.
     mv ./cloudflared $ARTIFACT_DIR/cloudflared-linux-$arch
 done
+
+freebsdArchs=("386" "amd64" "arm" "arm64")
+export TARGET_OS=freebsd
+for arch in ${linuxArchs[@]}; do
+    export TARGET_ARCH=$arch
+    
+    make cloudflared
+    mv ./cloudflared $ARTIFACT_DIR/cloudflared-freebsd-$arch
+done


### PR DESCRIPTION
As per issue #1053, currently no FreeBSD builds are available.

This PR updates the build_packages.sh script to add `cloudflared-freebsd-*` builds.
