### PR TITLE
fix typo in errcheck for response parsing logic in CreateTunnel routine

### DIFF
--- a/cfapi/tunnel.go
+++ b/cfapi/tunnel.go
@@ -93,7 +93,7 @@ func (r *RESTClient) CreateTunnel(name string, tunnelSecret []byte) (*TunnelWith
 	switch resp.StatusCode {
 	case http.StatusOK:
 		var tunnel TunnelWithToken
-		if serdeErr := parseResponse(resp.Body, &tunnel); err != nil {
+		if serdeErr := parseResponse(resp.Body, &tunnel); serdeErr != nil {
 			return nil, serdeErr
 		}
 		return &tunnel, nil


### PR DESCRIPTION
I ran [govanish](https://github.com/sivukhin/govanish) linter against `cloudflared` repo and it found suspicious issue: compiler eliminates err check in `CreateTunnel` function:
```go
...
case http.StatusOK:
	var tunnel TunnelWithToken
	if serdeErr := parseResponse(resp.Body, &tunnel); err != nil {
		return nil, serdeErr
	}
	return &tunnel, nil
...
```

```
2024/01/05 11:53:01 it seems like your code vanished from compiled binary: func=[CreateTunnel], file=[/home/sivukhin/code/cloudflared/cfapi/tunnel.go], lines=[97-97], snippet:
	return nil, serdeErr
```

Indeed, this is bug - `serdeErr` should be checked instead of `err`.

This PR fixes the code.