### PR TITLE
Fix broken links in `cmd/cloudflared/*.go` related to running tunnel as a service

### DIFF
--- a/cmd/cloudflared/macos_service.go
+++ b/cmd/cloudflared/macos_service.go
@@ -119,7 +119,7 @@ func installLaunchd(c *cli.Context) error {
 		log.Info().Msg("Installing cloudflared client as an user launch agent. " +
 			"Note that cloudflared client will only run when the user is logged in. " +
 			"If you want to run cloudflared client at boot, install with root permission. " +
-			"For more information, visit https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/run-tunnel/run-as-service")
+			"For more information, visit https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configure-tunnels/local-management/as-a-service")
 	}
 	etPath, err := os.Executable()
 	if err != nil {

--- a/cmd/cloudflared/updater/update.go
+++ b/cmd/cloudflared/updater/update.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	DefaultCheckUpdateFreq        = time.Hour * 24
-	noUpdateInShellMessage        = "cloudflared will not automatically update when run from the shell. To enable auto-updates, run cloudflared as a service: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/run-tunnel/as-a-service/"
+	noUpdateInShellMessage        = "cloudflared will not automatically update when run from the shell. To enable auto-updates, run cloudflared as a service: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configure-tunnels/local-management/as-a-service/"
 	noUpdateOnWindowsMessage      = "cloudflared will not automatically update on Windows systems."
 	noUpdateManagedPackageMessage = "cloudflared will not automatically update if installed by a package manager."
 	isManagedInstallFile          = ".installedFromPackageManager"

--- a/cmd/cloudflared/windows_service.go
+++ b/cmd/cloudflared/windows_service.go
@@ -26,7 +26,7 @@ import (
 const (
 	windowsServiceName        = "Cloudflared"
 	windowsServiceDescription = "Cloudflared agent"
-	windowsServiceUrl         = "https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/run-tunnel/as-a-service/windows/"
+	windowsServiceUrl         = "https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configure-tunnels/local-management/as-a-service/windows/"
 
 	recoverActionDelay      = time.Second * 20
 	failureCountResetPeriod = time.Hour * 24


### PR DESCRIPTION
This PR updates 3 broken links to document [run tunnel as a service](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/local-management/as-a-service/).

The one in [cmd/cloudflared/updater/update.go](https://github.com/cloudflare/cloudflared/compare/master...BWsix:cloudflared:master#diff-41cdc7fdfeb545f23c0990d2e13c4c34df74cfbdb2369b321b1e8688d98bde62) can be found by running `cloudflared tunnel run`:
```bash
> cloudflared tunnel run xxxx
2024-03-27T18:21:58Z INF Starting tunnel tunnelID=xxxx
2024-03-27T18:21:58Z INF Version 2024.3.0
2024-03-27T18:21:58Z INF GOOS: linux, GOVersion: go1.21.5-devel-cf, GoArch: amd64
2024-03-27T18:21:58Z INF Settings: xxxx
2024-03-27T18:21:58Z INF cloudflared will not automatically update when run from the shell. To enable auto-updates, run cloudflared as a service: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/run-tunnel/as-a-service/
^ the broken link is at the end of this line
```
The other two were found by manually grepping `developers.cloudflare.com` in the project.