### PR TITLE
Proposal: Support ingress rule matching for bastion mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ ifneq ($(TARGET_ARM), )
 	ARM_COMMAND := GOARM=$(TARGET_ARM)
 endif
 
-ifeq ($(TARGET_ARM), 7) 
+ifeq ($(TARGET_ARM), 7)
 	PACKAGE_ARCH := armhf
 else
 	PACKAGE_ARCH := $(TARGET_ARCH)

--- a/cmd/cloudflared/tunnel/ingress_subcommands.go
+++ b/cmd/cloudflared/tunnel/ingress_subcommands.go
@@ -138,7 +138,7 @@ func testURLCommand(c *cli.Context) error {
 		return errors.Wrap(err, "Validation failed")
 	}
 
-	_, i := ing.FindMatchingRule(requestURL.Hostname(), requestURL.Path)
+	_, i := ing.FindMatchingRule(requestURL.Hostname(), requestURL.Path, "")
 	fmt.Printf("Matched rule #%d\n", i)
 	fmt.Println(ing.Rules[i].MultiLineString())
 	return nil

--- a/ingress/origin_service.go
+++ b/ingress/origin_service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 
+	"github.com/cloudflare/cloudflared/config"
 	"github.com/cloudflare/cloudflared/hello"
 	"github.com/cloudflare/cloudflared/ipaccess"
 	"github.com/cloudflare/cloudflared/management"
@@ -151,6 +152,14 @@ func newBastionService() *tcpOverWSService {
 	}
 }
 
+func newBastionServiceWithDest(url *url.URL) *tcpOverWSService {
+	return &tcpOverWSService{
+		isBastion: true,
+		scheme:    url.Scheme,
+		dest:      url.Host,
+	}
+}
+
 func newSocksProxyOverWSService(accessPolicy *ipaccess.Policy) *socksProxyOverWSService {
 	proxy := socksProxyOverWSService{
 		conn: &socksProxyOverWSConnection{
@@ -170,8 +179,8 @@ func addPortIfMissing(uri *url.URL, port int) {
 }
 
 func (o *tcpOverWSService) String() string {
-	if o.isBastion {
-		return ServiceBastion
+	if o.isBastion && len(o.dest) == 0 {
+		return config.BastionFlag
 	}
 
 	if o.scheme != "" {

--- a/ingress/rule.go
+++ b/ingress/rule.go
@@ -59,7 +59,6 @@ func (r *Rule) Matches(hostname, path string) bool {
 	} else {
 		hostMatch = matchHost(r.Hostname, hostname)
 	}
-
 	punycodeHostMatch := false
 	if r.punycodeHostname != "" {
 		punycodeHostMatch = matchHost(r.punycodeHostname, hostname)

--- a/ingress/rule.go
+++ b/ingress/rule.go
@@ -59,6 +59,7 @@ func (r *Rule) Matches(hostname, path string) bool {
 	} else {
 		hostMatch = matchHost(r.Hostname, hostname)
 	}
+
 	punycodeHostMatch := false
 	if r.punycodeHostname != "" {
 		punycodeHostMatch = matchHost(r.punycodeHostname, hostname)


### PR DESCRIPTION
## Context

👋🏾 Hello from [Tines](https://tines.com/)! I work on the Platform Team, and we're big fans and heavy users of CF Tunnel. In a nutshell, we use Tunnel in our multi-tenant environment to proxy our customers' HTTP workloads from our cloud instances to their on-prem/self-hosted instances through Cloudflared Tunnel. We've built a small orchestration layer on top of the Tunnel that dynamically proxies our customers' requests from our HTTP client middleware via `cloudflared access` (entry node) to the customers' network (exit node).

Our setup operates in bastion mode, meaning the proxied request has a single destination.

## Problem

We are looking to eliminate any possibility of "data exfiltration." As you might guess, the exit node where the `cloudflared` tunnel runs can access virtually any service within its network boundary.

Tunnel Ingress Rules is an excellent feature that allows traffic routing to different services based on hostname. It also enables "blackhole-ing" incoming requests that do not match a certain hostname by declaring `http_status:404` as the service, for example.

However, ingress rules do not work with `bastionMode`. We could avoid using bastion mode, but given the scale (many multi tenant clusters) and dynamism of how we run Tunnels, this would require us to provision a new hostname/DNS per Tunnel in a multi-tenant env to leverage ingress rules in non-bastion mode, further necessitating some UX/DX changes.

## Proposal

My proposal is to extend the existing functionality of `bastionMode`. If `bastionMode` is set to true, and a `hostname` and `service` name are provided as part of the ingress rules config, then we attempt to match the `hostname` against the header `Cf-Access-Jump-Destination` in the incoming HTTP request. If the `Rule` matches, then we accordingly proxy the bastion request to the mentioned `service`. If a request does not match any service, then it falls into the usual catch-all behavior.

I have tested this setup in our environment, and it works as expected. That said, I'd like to propose this as a feature request for the project. I would also love to learn if there are opportunities to improve this approach or consider other options.

Given our reliance on Tunnel, we would also be happy to discuss what continued support and maintenance would look like.

Example config

```yaml
tunnel: aaaa-bbbb-cccc

ingress:
  - hostname: test-foobar-service.com
    service: http_status:200
  - hostname: "foobar.tunnel-dev.com"
    service: "http://localhost:9000"
  - hostname: "foobar1.tunnel-dev.com"
    service: "http://localhost:9002"
    originRequest:
      bastionMode: true
  - service: http_status:404
``` 

https://github.com/cloudflare/cloudflared/issues/1243