### PR TITLE
feat: option for cloudflared access login to only output jwt (#1249)

### DIFF
--- a/cmd/cloudflared/access/cmd.go
+++ b/cmd/cloudflared/access/cmd.go
@@ -27,6 +27,7 @@ import (
 
 const (
 	loginQuietFlag     = "quiet"
+	noPrettyFlag       = "no-pretty"
 	sshHostnameFlag    = "hostname"
 	sshDestinationFlag = "destination"
 	sshURLFlag         = "url"
@@ -96,6 +97,10 @@ func Commands() []*cli.Command {
 							Name:    loginQuietFlag,
 							Aliases: []string{"q"},
 							Usage:   "do not print the jwt to the command line",
+						},
+						&cli.BoolFlag{
+							Name:  noPrettyFlag,
+							Usage: "only print the jwt to the command line",
 						},
 					},
 				},
@@ -261,7 +266,12 @@ func login(c *cli.Context) error {
 	if c.Bool(loginQuietFlag) {
 		return nil
 	}
-	fmt.Fprintf(os.Stdout, "Successfully fetched your token:\n\n%s\n\n", cfdToken)
+
+	if c.Bool(noPrettyFlag) {
+		fmt.Fprintf(os.Stdout, cfdToken)
+	} else {
+		fmt.Fprintf(os.Stdout, "Successfully fetched your token:\n\n%s\n\n", cfdToken)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Adds a -no-pretty flag to cloudflared access login:

```shell
$ cloudflared access login -no-pretty $url
<TOKEN>
```

This removes the need to parse the token from the output message, making it easier for external applications.

This is a pretty small change change that makes it much simpler to use from, eg Python script.

With the current CLI, the caller must manually parse the output, eg:

```python
from subprocess import check_output

def get_auth_token(url) -> str:
    cmd = ["cloudflared", "access", "login", url]
    return check_output(cmd).decode("utf-8").strip().split()[-1]

```

Python's the simplest case here, but it's a step that doesn't really need to happen.


Also: the hardest part is coming up with a name for the flag, so I didn't thing too much about it, open to suggestions :)