### PR TITLE
Fixes GOAWAY frames not handled correctly with http2

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -199,6 +199,16 @@ func (p *Proxy) proxyHTTPRequest(
 		roundTripReq.Header.Set("Connection", "keep-alive")
 	}
 
+    // Handle GOAWAY frame to correctly retry a request
+    if roundTripReq.Body != nil {
+        roundTripReq.GetBody = func() (io.ReadCloser, err error) {
+            if err.Error() == "http2: Transport received Server's graceful shutdown GOAWAY" {
+                return roundTripReq.Body, nil
+            }
+            return nil, err
+        }
+    }
+
 	// Set the User-Agent as an empty string if not provided to avoid inserting golang default UA
 	if roundTripReq.Header.Get("User-Agent") == "" {
 		roundTripReq.Header.Set("User-Agent", "")


### PR DESCRIPTION
Fixes cloudflare/cloudflared#1273

Allows http2 requests to be retried only when a GOAWAY frame is received. 

GOAWAY spec: https://datatracker.ietf.org/doc/html/rfc7540#section-6.8
How GetBody is handled: https://github.com/golang/net/blob/master/http2/transport.go#L664