### PR TITLE
Use RELEASE_NOTES date instead of build date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ else
 	DEB_PACKAGE_NAME := $(BINARY_NAME)
 endif
 
-DATE          := $(shell date -u '+%Y-%m-%d-%H%M UTC')
+DATE          := $(shell date -u -r RELEASE_NOTES '+%Y-%m-%d-%H%M UTC')
 VERSION_FLAGS := -X "main.Version=$(VERSION)" -X "main.BuildTime=$(DATE)"
 ifdef PACKAGE_MANAGER
 	VERSION_FLAGS := $(VERSION_FLAGS) -X "github.com/cloudflare/cloudflared/cmd/cloudflared/updater.BuiltForPackageManager=$(PACKAGE_MANAGER)"


### PR DESCRIPTION
Use `RELEASE_NOTES` date instead of build date
to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.
This date call only works with GNU date and BSD date.

Alternatively, https://reproducible-builds.org/docs/source-date-epoch/#makefile could be implemented.

This patch was done while working on reproducible builds for openSUSE, sponsored by the NLnet NGI0 fund.