### PR TITLE
Adds a new command line for tunnel run for token file

### DIFF
--- a/cmd/cloudflared/tunnel/subcommands.go
+++ b/cmd/cloudflared/tunnel/subcommands.go
@@ -35,6 +35,7 @@ const (
 	CredFileFlag         = "credentials-file"
 	CredContentsFlag     = "credentials-contents"
 	TunnelTokenFlag      = "token"
+	TunnelTokenFileFlag  = "token-file"
 	overwriteDNSFlagName = "overwrite-dns"
 
 	LogFieldTunnelID = "tunnelID"
@@ -113,8 +114,13 @@ var (
 	})
 	tunnelTokenFlag = altsrc.NewStringFlag(&cli.StringFlag{
 		Name:    TunnelTokenFlag,
-		Usage:   "The Tunnel token. When provided along with credentials, this will take precedence.",
+		Usage:   "The Tunnel token. When provided along with credentials, this will take precedence. Also takes precedence over token-file",
 		EnvVars: []string{"TUNNEL_TOKEN"},
+	})
+	tunnelTokenFileFlag = altsrc.NewStringFlag(&cli.StringFlag{
+		Name:    TunnelTokenFileFlag,
+		Usage:   "Filepath at which to read the tunnel token. When provided along with credentials, this will take precedence.",
+		EnvVars: []string{"TUNNEL_TOKEN_FILE"},
 	})
 	forceDeleteFlag = &cli.BoolFlag{
 		Name:    "force",
@@ -613,6 +619,7 @@ func buildRunCommand() *cli.Command {
 		selectProtocolFlag,
 		featuresFlag,
 		tunnelTokenFlag,
+		tunnelTokenFileFlag,
 		icmpv4SrcFlag,
 		icmpv6SrcFlag,
 	}
@@ -652,12 +659,25 @@ func runCommand(c *cli.Context) error {
 			"your origin will not be reachable. You should remove the `hostname` property to avoid this warning.")
 	}
 
+	tokenStr := c.String(TunnelTokenFlag)
+	// Check if tokenStr is blank before checking for tokenFile
+	if tokenStr == "" {
+		if tokenFile := c.String(TunnelTokenFileFlag); tokenFile != "" {
+			data, err := os.ReadFile(tokenFile)
+			if err != nil {
+				return cliutil.UsageError("Failed to read token file: " + err.Error())
+			}
+			tokenStr = strings.TrimSpace(string(data))
+			if _, err := ParseToken(tokenStr); err != nil {
+				return cliutil.UsageError("Failed to parse token file: " + err.Error())
+			}
+		}
+	}
 	// Check if token is provided and if not use default tunnelID flag method
-	if tokenStr := c.String(TunnelTokenFlag); tokenStr != "" {
+	if tokenStr != "" {
 		if token, err := ParseToken(tokenStr); err == nil {
 			return sc.runWithCredentials(token.Credentials())
 		}
-
 		return cliutil.UsageError("Provided Tunnel token is not valid.")
 	} else {
 		tunnelRef := c.Args().First()


### PR DESCRIPTION
Adds a new command line flag for `tunnel run` which allows a file to be read for the token. I've left the token command line argument with priority. 

Would resolve #645 