### PR TITLE
persistent cfd quick tunnel

### DIFF
--- a/cmd/cloudflared/tunnel/subcommand_context.go
+++ b/cmd/cloudflared/tunnel/subcommand_context.go
@@ -261,7 +261,7 @@ func (sc *subcommandContext) runWithCredentials(credentials connection.Credentia
 	return StartServer(
 		sc.c,
 		buildInfo,
-		&connection.TunnelProperties{Credentials: credentials},
+		&connection.TunnelProperties{Credentials: credentials, QuickTunnelUrl: credentials.Hostname},
 		sc.log,
 	)
 }

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -53,6 +53,7 @@ type Credentials struct {
 	AccountTag   string
 	TunnelSecret []byte
 	TunnelID     uuid.UUID
+	Hostname     string
 }
 
 func (c *Credentials) Auth() pogs.TunnelAuth {


### PR DESCRIPTION
This PR introduces functionality to allow users to create and manage persistent Cloudflare quick tunnels. While quick tunnels are typically ephemeral, this feature enables users to set up long-lasting tunnels for ongoing projects or applications.

Create a new tunnel:
```curl -XPOST https://api.trycloudflare.com/tunnel -H "Content-Type: application/json"```

This generates a credential file (cred.json) containing tunnel details:
```json
{
  "TunnelID": "6eed86e6-3359-4439-8561-e7e8c16730b7",
  "name": "qt-iG1nZiARKhXjEkIQ2hfCzKesBCwEKeXq",
  "Hostname": "ill-indoor-global-price.trycloudflare.com",
  "AccountTag": "5ab4e9dfbd435d24068829fda0077963",
  "TunnelSecret": "ruHGVAUTEAXTdAhOMTCJ0o/+EY3kzcsukMC7ktSQ+SQ="
}
```

Create a configuration file (config.yml):
```yaml
url: localhost:8080
tunnel: 6eed86e6-3359-4439-8561-e7e8c16730b7
credential-file: /Users/0verflow/cred.json
```

Run the tunnel:
`./cloudflared tunnel --config /Users/0verflow/config.yml run --cred-file /Users/0verflow/cred.json`