### PR TITLE
Fix 'service install' on Mac OS

### DIFF
--- a/cmd/cloudflared/common_service.go
+++ b/cmd/cloudflared/common_service.go
@@ -24,7 +24,8 @@ func getServiceExtraArgsFromCliArgs(c *cli.Context, log *zerolog.Logger) ([]stri
 		// currently, we only support extra args for token
 		return buildArgsForToken(c, log)
 	} else {
-		// empty extra args
-		return make([]string, 0), nil
+		return []string{
+			"tunnel", "run",
+		}, nil
 	}
 }


### PR DESCRIPTION
`cloudflared service install` is not working as documented at https://github.com/cloudflare/cloudflared/issues/327

When **cloudflared** is started with [Mac OS launch agent](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html) it errors with:
```
Use `cloudflared tunnel run` to start tunnel {UUID}
Use `cloudflared tunnel run` to start tunnel {UUID}
Use `cloudflared tunnel run` to start tunnel {UUID}
```

A fix is suggested at https://github.com/cloudflare/cloudflared/issues/327#issuecomment-1763670368
And acknowledged by https://community.cloudflare.com/t/tunnel-error-on-macos-when-installed-as-service/339543/4

However, collective costs keep compounding.

The fix seems simple at least for my use case where only a single tunnel is used. But Not sure if there's other negative side effects.
`cloudflared service install` produces such `.plist`
```xml
cat ~/Library/LaunchAgents/com.cloudflare.cloudflared.plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
        <dict>
                <key>Label</key>
                <string>com.cloudflare.cloudflared</string>
                <key>ProgramArguments</key>
                <array>
                        <string>cloudflared</string>
                        <string>tunnel</string>
                        <string>run</string>
                </array>
                <key>RunAtLoad</key>
                <true/>
                <key>StandardOutPath</key>
                <string>/Users/povilas/Library/Logs/com.cloudflare.cloudflared.out.log</string>
                <key>StandardErrorPath</key>
                <string>/Users/povilas/Library/Logs/com.cloudflare.cloudflared.err.log</string>
                <key>KeepAlive</key>
                <dict>
                        <key>SuccessfulExit</key>
                        <false/>
                </dict>
                <key>ThrottleInterval</key>
                <integer>5</integer>
        </dict>
</plist>
```

as opposed to
```xml
                <array>
                        <string>cloudflared</string>
                </array>
```