### PR TITLE
add: new go-fuzz targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,18 @@ cover:
 	# Generate the HTML report that can be viewed from the browser in CI.
 	$Q go tool cover -html ".cover/c.out" -o .cover/all.html
 
+.PHONY: fuzz
+fuzz:
+	@go test -fuzz=FuzzIPDecoder -fuzztime=600s ./packet
+	@go test -fuzz=FuzzICMPDecoder -fuzztime=600s ./packet
+	@go test -fuzz=FuzzSessionWrite -fuzztime=600s ./quic/v3
+	@go test -fuzz=FuzzSessionServe -fuzztime=600s ./quic/v3
+	@go test -fuzz=FuzzRegistrationDatagram -fuzztime=600s ./quic/v3
+	@go test -fuzz=FuzzPayloadDatagram -fuzztime=600s ./quic/v3
+	@go test -fuzz=FuzzRegistrationResponseDatagram -fuzztime=600s ./quic/v3
+	@go test -fuzz=FuzzNewIdentity -fuzztime=600s ./tracing
+	@go test -fuzz=FuzzNewAccessValidator -fuzztime=600s ./validation
+
 .PHONY: install-go
 install-go:
 	rm -rf ${CF_GO_PATH}

--- a/packet/decoder_test.go
+++ b/packet/decoder_test.go
@@ -254,3 +254,18 @@ func (u *UDP) EncodeLayers() ([]gopacket.SerializableLayer, error) {
 	udpLayer.SetNetworkLayerForChecksum(ipLayers[0].(gopacket.NetworkLayer))
 	return append(ipLayers, &udpLayer), nil
 }
+
+func FuzzIPDecoder(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		ipDecoder := NewIPDecoder()
+		ipDecoder.Decode(RawPacket{Data: data})
+
+	})
+}
+
+func FuzzICMPDecoder(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		icmpDecoder := NewICMPDecoder()
+		icmpDecoder.Decode(RawPacket{Data: data})
+	})
+}

--- a/quic/v3/datagram_test.go
+++ b/quic/v3/datagram_test.go
@@ -350,3 +350,30 @@ func compareRegistrationDatagrams(t *testing.T, l *v3.UDPSessionRegistrationData
 		l.IdleDurationHint == r.IdleDurationHint &&
 		l.Traced == r.Traced
 }
+
+func FuzzRegistrationDatagram(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		unmarshaled := v3.UDPSessionRegistrationDatagram{}
+		err := unmarshaled.UnmarshalBinary(data)
+		if err == nil {
+			_, _ = unmarshaled.MarshalBinary()
+		}
+	})
+}
+
+func FuzzPayloadDatagram(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		unmarshaled := v3.UDPSessionPayloadDatagram{}
+		_ = unmarshaled.UnmarshalBinary(data)
+	})
+}
+
+func FuzzRegistrationResponseDatagram(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		unmarshaled := v3.UDPSessionRegistrationResponseDatagram{}
+		err := unmarshaled.UnmarshalBinary(data)
+		if err == nil {
+			_, _ = unmarshaled.MarshalBinary()
+		}
+	})
+}

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -72,3 +72,9 @@ func TestAddingSpansWithNilMap(t *testing.T) {
 	// a panic shouldn't occur
 	tr.AddSpans(nil)
 }
+
+func FuzzNewIdentity(f *testing.F) {
+	f.Fuzz(func(t *testing.T, trace string) {
+		_, _ = NewIdentity(trace)
+	})
+}

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -197,3 +197,10 @@ func createSecureMockServerAndClient(handler http.Handler) (*httptest.Server, *h
 
 	return server, client, nil
 }
+
+func FuzzNewAccessValidator(f *testing.F) {
+	f.Fuzz(func(t *testing.T, domain string, issuer string, applicationAUD string) {
+		ctx := context.Background()
+		_, _ = NewAccessValidator(ctx, domain, issuer, applicationAUD)
+	})
+}


### PR DESCRIPTION
Some new go-fuzz targets.

These are the same test targets that I used for my HackerOne report.