### PR TITLE
Fix: Can't use Unix Sockets in Quick Tunnel mode

### DIFF
--- a/cmd/cloudflared/tunnel/cmd.go
+++ b/cmd/cloudflared/tunnel/cmd.go
@@ -215,6 +215,7 @@ var (
 		"overwrite-dns",
 		"help",
 	}
+	runQuickTunnel = RunQuickTunnel
 )
 
 func Flags() []cli.Flag {
@@ -313,9 +314,9 @@ func TunnelCommand(c *cli.Context) error {
 	// Run a quick tunnel
 	// A unauthenticated named tunnel hosted on <random>.<quick-tunnels-service>.com
 	// We don't support running proxy-dns and a quick tunnel at the same time as the same process
-	shouldRunQuickTunnel := c.IsSet("url") || c.IsSet(ingress.HelloWorldFlag)
+	shouldRunQuickTunnel := c.IsSet("url") || c.IsSet("unix-socket") || c.IsSet(ingress.HelloWorldFlag)
 	if !c.IsSet("proxy-dns") && c.String("quick-service") != "" && shouldRunQuickTunnel {
-		return RunQuickTunnel(sc)
+		return runQuickTunnel(sc)
 	}
 
 	// If user provides a config, check to see if they meant to use `tunnel run` instead

--- a/cmd/cloudflared/tunnel/cmd_test.go
+++ b/cmd/cloudflared/tunnel/cmd_test.go
@@ -21,40 +21,34 @@ func TestHostnameFromURI(t *testing.T) {
 
 func TestShouldRunQuickTunnel(t *testing.T) {
 	tests := []struct {
-		name              string
-		flags             map[string]string
-		expectQuickTunnel bool
-		expectError       bool
+		name        string
+		flags       map[string]string
+		expectError bool
 	}{
 		{
-			name:              "Quick tunnel with URL set",
-			flags:             map[string]string{"url": "http://127.0.0.1:8080", "quick-service": "https://fakeapi.trycloudflare.com"},
-			expectQuickTunnel: true,
-			expectError:       false,
+			name:        "Quick tunnel with URL set",
+			flags:       map[string]string{"url": "http://127.0.0.1:8080", "quick-service": "https://fakeapi.trycloudflare.com"},
+			expectError: false,
 		},
 		{
-			name:              "Quick tunnel with unix-socket set",
-			flags:             map[string]string{"unix-socket": "/tmp/socket", "quick-service": "https://fakeapi.trycloudflare.com"},
-			expectQuickTunnel: true,
-			expectError:       false,
+			name:        "Quick tunnel with unix-socket set",
+			flags:       map[string]string{"unix-socket": "/tmp/socket", "quick-service": "https://fakeapi.trycloudflare.com"},
+			expectError: false,
 		},
 		{
-			name:              "Quick tunnel with hello-world flag",
-			flags:             map[string]string{"hello-world": "true", "quick-service": "https://fakeapi.trycloudflare.com"},
-			expectQuickTunnel: true,
-			expectError:       false,
+			name:        "Quick tunnel with hello-world flag",
+			flags:       map[string]string{"hello-world": "true", "quick-service": "https://fakeapi.trycloudflare.com"},
+			expectError: false,
 		},
 		{
-			name:              "Quick tunnel with proxy-dns (invalid combo)",
-			flags:             map[string]string{"url": "http://127.0.0.1:9090", "proxy-dns": "true", "quick-service": "https://fakeapi.trycloudflare.com"},
-			expectQuickTunnel: false,
-			expectError:       true,
+			name:        "Quick tunnel with proxy-dns (invalid combo)",
+			flags:       map[string]string{"url": "http://127.0.0.1:9090", "proxy-dns": "true", "quick-service": "https://fakeapi.trycloudflare.com"},
+			expectError: true,
 		},
 		{
-			name:              "No quick-service set",
-			flags:             map[string]string{"url": "http://127.0.0.1:9090"},
-			expectQuickTunnel: false,
-			expectError:       true,
+			name:        "No quick-service set",
+			flags:       map[string]string{"url": "http://127.0.0.1:9090"},
+			expectError: true,
 		},
 	}
 
@@ -79,11 +73,10 @@ func TestShouldRunQuickTunnel(t *testing.T) {
 
 			// Validate
 			if tt.expectError {
+				assert.False(t, mockCalled)
 				require.Error(t, err)
-			} else if tt.expectQuickTunnel {
-				assert.True(t, mockCalled)
-				require.NoError(t, err)
 			} else {
+				assert.True(t, mockCalled)
 				require.NoError(t, err)
 			}
 		})

--- a/cmd/cloudflared/tunnel/cmd_test.go
+++ b/cmd/cloudflared/tunnel/cmd_test.go
@@ -1,9 +1,12 @@
 package tunnel
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 )
 
 func TestHostnameFromURI(t *testing.T) {
@@ -14,4 +17,84 @@ func TestHostnameFromURI(t *testing.T) {
 	assert.Equal(t, "localhost:3390", hostnameFromURI("rdp://localhost:3390"))
 	assert.Equal(t, "", hostnameFromURI("trash"))
 	assert.Equal(t, "", hostnameFromURI("https://awesomesauce.com"))
+}
+
+func TestShouldRunQuickTunnel(t *testing.T) {
+	tests := []struct {
+		name              string
+		flags             map[string]string
+		expectQuickTunnel bool
+		expectError       bool
+	}{
+		{
+			name:              "Quick tunnel with URL set",
+			flags:             map[string]string{"url": "http://127.0.0.1:8080", "quick-service": "https://fakeapi.trycloudflare.com"},
+			expectQuickTunnel: true,
+			expectError:       false,
+		},
+		{
+			name:              "Quick tunnel with unix-socket set",
+			flags:             map[string]string{"unix-socket": "/tmp/socket", "quick-service": "https://fakeapi.trycloudflare.com"},
+			expectQuickTunnel: true,
+			expectError:       false,
+		},
+		{
+			name:              "Quick tunnel with hello-world flag",
+			flags:             map[string]string{"hello-world": "true", "quick-service": "https://fakeapi.trycloudflare.com"},
+			expectQuickTunnel: true,
+			expectError:       false,
+		},
+		{
+			name:              "Quick tunnel with proxy-dns (invalid combo)",
+			flags:             map[string]string{"url": "http://127.0.0.1:9090", "proxy-dns": "true", "quick-service": "https://fakeapi.trycloudflare.com"},
+			expectQuickTunnel: false,
+			expectError:       true,
+		},
+		{
+			name:              "No quick-service set",
+			flags:             map[string]string{"url": "http://127.0.0.1:9090"},
+			expectQuickTunnel: false,
+			expectError:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mock RunQuickTunnel Function
+			originalRunQuickTunnel := runQuickTunnel
+			defer func() { runQuickTunnel = originalRunQuickTunnel }()
+			mockCalled := false
+			runQuickTunnel = func(sc *subcommandContext) error {
+				mockCalled = true
+				return nil
+			}
+
+			// Mock App Context
+			app := &cli.App{}
+			set := flagSetFromMap(tt.flags)
+			context := cli.NewContext(app, set, nil)
+
+			// Call TunnelCommand
+			err := TunnelCommand(context)
+
+			// Validate
+			if tt.expectError {
+				require.Error(t, err)
+			} else if tt.expectQuickTunnel {
+				assert.True(t, mockCalled)
+				require.NoError(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func flagSetFromMap(flags map[string]string) *flag.FlagSet {
+	set := flag.NewFlagSet("test", 0)
+	for key, value := range flags {
+		set.String(key, "", "")
+		set.Set(key, value)
+	}
+	return set
 }


### PR DESCRIPTION
From https://github.com/cloudflare/cloudflared/issues/1294:

> When you try to use a unix socket (--unix-socket) without a domain configured, cloudflared still asks for the --url parameter.

This PR aims to address the above by adding `unix-socket` as an accepted flag for spawning quick tunnels. I unfortunately couldn't find an elegant way to mock out the `RunQuickTunnel` command, so I had to add a small work around. Please let me know if there is a better standard for this.

Thanks!