### PR TITLE
Introduce a custom header which servers can return to request cloudflared to not buffer the response.

### DIFF
--- a/connection/connection.go
+++ b/connection/connection.go
@@ -29,6 +29,8 @@ const (
 	contentTypeHeader = "content-type"
 	sseContentType    = "text/event-stream"
 	grpcContentType   = "application/grpc"
+
+	FlushResponseHeader  = "cf-cloudflared-flush-response"
 )
 
 var (
@@ -270,6 +272,10 @@ type ConnectedFuse interface {
 // Helper method to let the caller know what content-types should require a flush on every
 // write to a ResponseWriter.
 func shouldFlush(headers http.Header) bool {
+	if headers.Get(FlushResponseHeader) == "yes" {
+		return true
+	}
+
 	if contentType := headers.Get(contentTypeHeader); contentType != "" {
 		contentType = strings.ToLower(contentType)
 		for _, c := range flushableContentTypes {


### PR DESCRIPTION
cloudflared currently only supports bypassing its response buffering through the Content-Type. This PR adds support for a custom header `cf-cloudflared-flush-response` which when present and having a value of `yes`, disables response buffering as well.