### PR TITLE
Improve `http_status` validation

### DIFF
--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -3,6 +3,7 @@ package ingress
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -260,7 +261,7 @@ func validateIngress(ingress []config.UnvalidatedIngressRule, defaults OriginReq
 			if err != nil {
 				return Ingress{}, errors.Wrap(err, "invalid HTTP status code")
 			}
-			if statusCode < 100 || statusCode > 999 {
+			if http.StatusText(statusCode) == "" {
 				return Ingress{}, fmt.Errorf("invalid HTTP status code: %d", statusCode)
 			}
 			srv := newStatusCode(statusCode)

--- a/ingress/ingress_test.go
+++ b/ingress/ingress_test.go
@@ -247,10 +247,18 @@ ingress:
 			wantErr: true,
 		},
 		{
-			name: "Invalid HTTP status code",
+			name: "Invalid HTTP status code(8080)",
 			args: args{rawYAML: `
 ingress:
  - service: http_status:8080
+`},
+			wantErr: true,
+		},
+		{
+			name: "Invalid HTTP status code(666)",
+			args: args{rawYAML: `
+ingress:
+ - service: http_status:666
 `},
 			wantErr: true,
 		},


### PR DESCRIPTION
Currently, the validation of the http status input is a numeric range, so an invalid status code can be entered. Change to check if the http status code exists or not.
related to https://github.com/cloudflare/cloudflared/issues/1389 .

![2024-12-24-11 09 30@2x](https://github.com/user-attachments/assets/38cbe955-0aae-4abb-a53b-bc0807f3b502)

Even if this validation were added, it is still possible to set it from the Web UI( https://one.dash.cloudflare.com/ ), so that needs to be modified as well.

Those that exist as http status but are not normally used can be registered, but I think this should be handled by the web UI. 
(Personally, I don't see a problem with using the joke status code because it's funny.)
![image(1)](https://github.com/user-attachments/assets/5f0551fd-a6a9-45f8-bb4f-42d2506a83e4)
![2024-12-24-11 03 22](https://github.com/user-attachments/assets/9a0c6885-4089-4c64-bb5d-bd36c64da4b0)
