### PR TITLE
fix: expand home directory for credentials file

### DIFF
--- a/cmd/cloudflared/tunnel/subcommand_context.go
+++ b/cmd/cloudflared/tunnel/subcommand_context.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/urfave/cli/v2"
@@ -54,7 +55,12 @@ func newSubcommandContext(c *cli.Context) (*subcommandContext, error) {
 // Returns something that can find the given tunnel's credentials file.
 func (sc *subcommandContext) credentialFinder(tunnelID uuid.UUID) CredFinder {
 	if path := sc.c.String(CredFileFlag); path != "" {
-		return newStaticPath(path, sc.fs)
+		// Expand path if CredFileFlag contains `~`
+		absPath, err := homedir.Expand(path)
+		if err != nil {
+			return newStaticPath(path, sc.fs)
+		}
+		return newStaticPath(absPath, sc.fs)
 	}
 	return newSearchByID(tunnelID, sc.c, sc.log, sc.fs)
 }


### PR DESCRIPTION
## Issue

The [documentation for creating a tunnel's configuration file](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/get-started/create-local-tunnel/#4-create-a-configuration-file) does not specify that the `credentials-file` field in `config.yml` needs to be an absolute path.

A user (E.G. me 🤦) might add a path like `~/.cloudflared/<uuid>.json` and wonder why the `cloudflared tunnel run` command is throwing a credentials file not found error. Although one might consider it intuitive, it's not a fair assumption as a lot of CLI tools allow file paths with `~` for specifying files.

P.S. The tunnel ID in the following snippet is not a real tunnel ID, I just generated it.
```
url: http://localhost:8000
tunnel: 958a1ef6-ff8c-4455-825a-5aed91242135
credentials-file: ~/.cloudflared/958a1ef6-ff8c-4455-825a-5aed91242135.json
```

Furthermore, the error has a confusing message for the user as the file at the logged path actually exists, it is just that `os.Stat` failed because it could not expand the `~`.

## Solution

This commit fixes the above issue by running a `homedir.Expand` on the `credentials-file` path in the `credentialFinder` function.