### PR TITLE
fix: Make 'cloudflared access token' return with a non-zero exit code when token has expired

### DIFF
--- a/cmd/cloudflared/access/cmd.go
+++ b/cmd/cloudflared/access/cmd.go
@@ -388,8 +388,12 @@ func generateToken(c *cli.Context) error {
 	}
 	tok, err := token.GetAppTokenIfExists(appInfo)
 	if err != nil || tok == "" {
-		fmt.Fprintln(os.Stderr, "Unable to find token for provided application. Please run login command to generate token.")
-		return err
+		message := "Unable to find valid token for provided application. Please run login command to generate token."
+		fmt.Fprintln(os.Stderr, message)
+		if err != nil {
+			return err
+		}
+		return errors.New(message)
 	}
 
 	if _, err := fmt.Fprint(os.Stdout, tok); err != nil {


### PR DESCRIPTION
I've been working on a helper script for a project that automatically fetches an access token and updates a local `.env` file with the token. Sometimes the script would fail to detect that `cloudflared` failed to fetch a token by looking at its exit code.

```sh
token=$(cloudflared access token -app=$cf_access_domain)
code=$?
echo "exit code $code"
if [ $code -ne 0 ] || [ -z "$token" ]; then
    echo "'cloudflared access token' failed. Attempting to log in..."
    cloudflared access login $cf_access_domain
    token=$(cloudflared access token -app=$cf_access_domain)
fi
```

I needed to add the `[ -z "$token" ]` test to catch these cases.

Looking at `cloudflared`'s source, my guess is the command prints an empty token and exits with zero when `GetAppTokenIfExists` detects that the token has been expired and there was no error removing the file that the token was saved to.

https://github.com/cloudflare/cloudflared/blob/3f6b1f24d036fc9a04270d418d78037d392a1f44/token/token.go#L435-L438