### PR TITLE
Use numeric user in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # use a builder image for building cloudflare
 ARG TARGET_GOOS
 ARG TARGET_GOARCH
-FROM golang:1.22.10 as builder
+FROM golang:1.22.10 AS builder
 ENV GO111MODULE=on \
   CGO_ENABLED=0 \
   TARGET_GOOS=${TARGET_GOOS} \
@@ -30,7 +30,7 @@ LABEL org.opencontainers.image.source="https://github.com/cloudflare/cloudflared
 COPY --from=builder --chown=nonroot /go/src/github.com/cloudflare/cloudflared/cloudflared /usr/local/bin/
 
 # run as non-privileged user
-USER nonroot
+USER 1002
 
 # command / entrypoint of container
 ENTRYPOINT ["cloudflared", "--no-autoupdate"]

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,10 +1,10 @@
 # use a builder image for building cloudflare
-FROM golang:1.22.10 as builder
+FROM golang:1.22.10 AS builder
 ENV GO111MODULE=on \
   CGO_ENABLED=0 \
   # the CONTAINER_BUILD envvar is used set github.com/cloudflare/cloudflared/metrics.Runtime=virtual
   # which changes how cloudflared binds the metrics server
-  CONTAINER_BUILD=1 
+  CONTAINER_BUILD=1
 
 WORKDIR /go/src/github.com/cloudflare/cloudflared/
 
@@ -25,7 +25,7 @@ LABEL org.opencontainers.image.source="https://github.com/cloudflare/cloudflared
 COPY --from=builder --chown=nonroot /go/src/github.com/cloudflare/cloudflared/cloudflared /usr/local/bin/
 
 # run as non-privileged user
-USER nonroot
+USER 1002
 
 # command / entrypoint of container
 ENTRYPOINT ["cloudflared", "--no-autoupdate"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,5 +1,5 @@
 # use a builder image for building cloudflare
-FROM golang:1.22.10 as builder
+FROM golang:1.22.10 AS builder
 ENV GO111MODULE=on \
   CGO_ENABLED=0 \
   # the CONTAINER_BUILD envvar is used set github.com/cloudflare/cloudflared/metrics.Runtime=virtual
@@ -25,7 +25,7 @@ LABEL org.opencontainers.image.source="https://github.com/cloudflare/cloudflared
 COPY --from=builder --chown=nonroot /go/src/github.com/cloudflare/cloudflared/cloudflared /usr/local/bin/
 
 # run as non-privileged user
-USER nonroot
+USER 1002
 
 # command / entrypoint of container
 ENTRYPOINT ["cloudflared", "--no-autoupdate"]

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.10 as builder
+FROM golang:1.22.10 AS builder
 ENV GO111MODULE=on \
   CGO_ENABLED=0
 WORKDIR /go/src/github.com/cloudflare/cloudflared/


### PR DESCRIPTION
Hi, this improvement allows 'cloudflared' to run in Kubernetes with 'runAsNonRoot: true' without requiring force change user ID to be numeric.