### PR TITLE
fix go vet  non-constant format string in calls

### DIFF
--- a/cmd/cloudflared/tunnel/subcommands.go
+++ b/cmd/cloudflared/tunnel/subcommands.go
@@ -761,7 +761,7 @@ func runCommand(c *cli.Context) error {
 		if tokenFile := c.String(TunnelTokenFileFlag); tokenFile != "" {
 			data, err := os.ReadFile(tokenFile)
 			if err != nil {
-				return cliutil.UsageError("Failed to read token file: " + err.Error())
+				return cliutil.UsageError("Failed to read token file: %s", err.Error())
 			}
 			tokenStr = strings.TrimSpace(string(data))
 		}

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -113,7 +113,7 @@ func ParseIngressFromConfigAndCLI(conf *config.Configuration, c *cli.Context, lo
 		// If no token is provided, the probability of NOT being a remotely managed tunnel is higher.
 		// So, we should warn the user that no ingress rules were found, because remote configuration will most likely not exist.
 		if !c.IsSet("token") {
-			log.Warn().Msgf(ErrNoIngressRulesCLI.Error())
+			log.Warn().Msg(ErrNoIngressRulesCLI.Error())
 		}
 		return newDefaultOrigin(c, log), nil
 	}

--- a/ingress/origin_proxy.go
+++ b/ingress/origin_proxy.go
@@ -74,7 +74,7 @@ func (o *httpService) SetOriginServerName(req *http.Request) {
 
 func (o *statusCode) RoundTrip(_ *http.Request) (*http.Response, error) {
 	if o.defaultResp {
-		o.log.Warn().Msgf(ErrNoIngressRulesCLI.Error())
+		o.log.Warn().Msg(ErrNoIngressRulesCLI.Error())
 	}
 	resp := &http.Response{
 		StatusCode: o.code,

--- a/tunnelrpc/pogs/configuration_manager.go
+++ b/tunnelrpc/pogs/configuration_manager.go
@@ -2,7 +2,7 @@ package pogs
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	capnp "zombiezen.com/go/capnproto2"
 	"zombiezen.com/go/capnproto2/rpc"
@@ -96,7 +96,7 @@ func (p *UpdateConfigurationResponse) Unmarshal(s proto.UpdateConfigurationRespo
 		return err
 	}
 	if respErr != "" {
-		p.Err = fmt.Errorf(respErr)
+		p.Err = errors.New(respErr)
 	}
 	return nil
 }

--- a/tunnelrpc/pogs/session_manager.go
+++ b/tunnelrpc/pogs/session_manager.go
@@ -2,6 +2,7 @@ package pogs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -127,7 +128,7 @@ func (p *RegisterUdpSessionResponse) Unmarshal(s proto.RegisterUdpSessionRespons
 		return err
 	}
 	if respErr != "" {
-		p.Err = fmt.Errorf(respErr)
+		p.Err = errors.New(respErr)
 	}
 	p.Spans, err = s.Spans()
 	if err != nil {


### PR DESCRIPTION
multiple non-constant format string in calls fixed.