### PR TITLE
Add build UUID

### DIFF
--- a/.teamcity/install-cloudflare-go.sh
+++ b/.teamcity/install-cloudflare-go.sh
@@ -3,6 +3,6 @@
 cd /tmp
 git clone -q https://github.com/cloudflare/go
 cd go/src
-# https://github.com/cloudflare/go/tree/af19da5605ca11f85776ef7af3384a02a315a52b is version go1.22.5-devel-cf
-git checkout -q af19da5605ca11f85776ef7af3384a02a315a52b
+# https://github.com/cloudflare/go/tree/37bc41c6ff79507200a315b72834fce6ca427a7e is version go1.22.12-devel-cf
+git checkout -q 37bc41c6ff79507200a315b72834fce6ca427a7e
 ./make.bash

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ ifeq ($(FIPS), true)
 	VERSION_FLAGS := $(VERSION_FLAGS) -X "main.BuildType=FIPS"
 endif
 
-LDFLAGS := -ldflags='$(VERSION_FLAGS) $(LINK_FLAGS)'
+LDFLAGS := -ldflags='$(VERSION_FLAGS) $(LINK_FLAGS) -B gobuildid'
 ifneq ($(GO_BUILD_TAGS),)
 	GO_BUILD_TAGS := -tags "$(GO_BUILD_TAGS)"
 endif


### PR DESCRIPTION
Recent macOS versions require user permissions to access the local network. This can only be granted for binaries which have a LC_UUID load command. Go 1.24 adds the UUID by default, but the fix was backported to Go 1.22.9 and 1.23 where it requires passing `-B gobuildid` to the linker.

cloudflared uses Cloudflare's Go fork which is based on Go 1.22.5 and doesn't have the backport. Because of this, cloudflared can't talk to any machine on the local network (no route to host) when it's runnning as a non-root user.

This workaround updates the Go fork to go1.22.12-devel-cf and adds `-B gobuildid` so that the binary now has a UUID:

```
❯ dwarfdump --uuid /opt/homebrew/bin/cloudflared
UUID: F2088E17-03A1-34B1-F12C-0DF01F00BA32 (arm64) /opt/homebrew/bin/cloudflared
```

Fixes #1460