### PR TITLE
Ejherlig cfgo deprecation patch

### DIFF
--- a/.teamcity/install-cloudflare-go.sh
+++ b/.teamcity/install-cloudflare-go.sh
@@ -1,8 +1,0 @@
-# !/usr/bin/env bash
-
-cd /tmp
-git clone -q https://github.com/cloudflare/go
-cd go/src
-# https://github.com/cloudflare/go/tree/af19da5605ca11f85776ef7af3384a02a315a52b is version go1.22.5-devel-cf
-git checkout -q af19da5605ca11f85776ef7af3384a02a315a52b
-./make.bash

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Downloads are available as standalone binaries, a Docker image, and Debian, RPM,
 * Binaries, Debian, and RPM packages for Linux [can be found here](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation#linux)
 * A Docker image of `cloudflared` is [available on DockerHub](https://hub.docker.com/r/cloudflare/cloudflared)
 * You can install on Windows machines with the [steps here](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation#windows)
-* To build from source, first you need to download the go toolchain by running `./.teamcity/install-cloudflare-go.sh` and follow the output. Then you can run `make cloudflared`
+* To build from source, follow the steps in the [Development](#development) section below.
 
 User documentation for Cloudflare Tunnel can be found at https://developers.cloudflare.com/cloudflare-one/connections/connect-apps
 
@@ -62,7 +62,7 @@ For example, as of January 2023 Cloudflare will support cloudflared version 2023
 ### Requirements
 - [GNU Make](https://www.gnu.org/software/make/)
 - [capnp](https://capnproto.org/install.html)
-- [cloudflare go toolchain](https://github.com/cloudflare/go)
+- [go >= 1.24](https://go.dev/doc/install) (the prior cloudflare-specific go toolchain is no longer used)
 - Optional tools:
   - [capnpc-go](https://pkg.go.dev/zombiezen.com/go/capnproto2/capnpc-go)
   - [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports)


### PR DESCRIPTION
Commit 96ce66b to update go to 1.24 deprecates the requirement to compile with cloudflare-go, while the README still reflected the cfgo requirement, and the .teamcity/install-cloudflare-go.sh script is now obsolete.