### PR TITLE
Add loongarch64 architecture support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,8 @@ else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 4),armv)
     TARGET_ARCH ?= arm
 else ifeq ($(LOCAL_ARCH),s390x)
     TARGET_ARCH ?= s390x
+else ifeq ($(LOCAL_ARCH),loongarch64)
+    TARGET_ARCH ?= loong64 
 else
     $(error This system's architecture $(LOCAL_ARCH) isn't supported)
 endif


### PR DESCRIPTION
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.
Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html

Hello maintainers,
This is an introduction to LoongArch64, an architecture that has been well validated and upstreamed in major toolchains such as GCC, Golang, Rust, and Binutils. We would appreciate Cloudflared adding support for it.
The package builds successfully on my native LoongArch64 hardware, and the architecture is also supported in QEMU for emulation/testing. Looking forward to your feedback!
