### PR TITLE
fix s3 streaming uploads broken by go/net bump

### DIFF
--- a/connection/quic_connection.go
+++ b/connection/quic_connection.go
@@ -386,10 +386,11 @@ func setContentLength(req *http.Request) error {
 }
 
 func isTransferEncodingChunked(req *http.Request) bool {
+	contentEncodingVal := req.Header.Get("Content-Encoding") // AWS S3 uses Content-Encoding: aws-chunked
 	transferEncodingVal := req.Header.Get("Transfer-Encoding")
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding suggests that this can be a comma
 	// separated value as well.
-	return strings.Contains(strings.ToLower(transferEncodingVal), "chunked")
+	return strings.Contains(strings.ToLower(transferEncodingVal), "chunked") || strings.Contains(strings.ToLower(contentEncodingVal), "chunked")
 }
 
 // A helper struct that guarantees a call to close only affects read side, but not write side.


### PR DESCRIPTION
fixes #1511 

go/net module was updated,
https://github.com/golang/go/commit/450f3f608d409e2b3d76af071ec726efacbdd17b#diff-a50801014d4fc5373ebbddfedea688dbf90f9c68542b6d62b3ee4b2fa641e986R72

cloudflared sets `NoBody` for non chunked and zero content length requests as seen below:
```
        // Go's client defaults to chunked encoding after a 200ms delay if the following cases are true:
        //   * the request body blocks
        //   * the content length is not set (or set to -1)
        //   * the method doesn't usually have a body (GET, HEAD, DELETE, ...)
        //   * there is no transfer-encoding=chunked already set.
        // So, if transfer cannot be chunked and content length is 0, we dont set a request body.
        if !isWebsocket && !isTransferEncodingChunked(req) && req.ContentLength == 0 {
                req.Body = http.NoBody
        }
```

However, when `content-length` is not set, it defaults to `0`, and AWS S3 uses `content-encoding: aws-chunked` instead of `transfer-encoding`, causing cloudflared to set `NoBody`.
With the go/net module 0.26.0->0.40.0 bump, it explicitly sets `content-length: 0` if request is NoBody, even when original request does not have a `content-length` header. This causes S3-compatible storages, at least minio, and potentially other applications to fail, because the uploaded body size does not match the header.

The fix simply searches the string `chunked` in `content-encoding` alongside `transfer-encoding`.