### PR TITLE
feat: Add custom HTTP header management via CLI flags and config files

### DIFF
--- a/cmd/cloudflared/tunnel/cmd.go
+++ b/cmd/cloudflared/tunnel/cmd.go
@@ -1056,6 +1056,19 @@ func configureProxyFlags(shouldHide bool) []cli.Flag {
 			Hidden:  shouldHide,
 			Value:   false,
 		}),
+		altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
+			Name:    "header",
+			Aliases: []string{"H"},
+			Usage:   "Add custom header when forwarding to origin (format: 'Name: Value')",
+			EnvVars: []string{"TUNNEL_HEADERS"},
+			Hidden:  shouldHide,
+		}),
+		altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
+			Name:    "remove-header",
+			Usage:   "Remove header when forwarding to origin",
+			EnvVars: []string{"TUNNEL_REMOVE_HEADERS"},
+			Hidden:  shouldHide,
+		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:    cfdflags.ManagementHostname,
 			Usage:   "Management hostname to signify incoming management requests",

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -231,6 +231,10 @@ type OriginRequestConfig struct {
 	Http2Origin *bool `yaml:"http2Origin" json:"http2Origin,omitempty"`
 	// Access holds all access related configs
 	Access *AccessConfig `yaml:"access" json:"access,omitempty"`
+	// Custom headers to add/modify when forwarding to origin
+	Headers map[string]string `yaml:"headers" json:"headers,omitempty"`
+	// Headers to remove when forwarding to origin
+	RemoveHeaders []string `yaml:"removeHeaders" json:"removeHeaders,omitempty"`
 }
 
 type AccessConfig struct {


### PR DESCRIPTION
##  Custom HTTP Header Management

This PR adds the ability to add, modify, and remove HTTP headers when forwarding requests to origin services through Cloudflare Tunnel.

### Works with
- **CLI Flags**: `--header` and `--remove-header` for quick tunnel setups
- **Configuration Files**: Support for headers in YAML/JSON config files

### add the feature request: #1499 

### Usage

#### CLI Flags (Quick Tunnels)
```bash
cloudflared tunnel --url http://localhost:3000 \
  --header "X-API-Key: your-api-key" \ # custom headers
  --header "Authorization: Bearer 123456789" \
  --header "X-Service-Name: my-service"

cloudflared tunnel --url http://localhost:3000 \
  --remove-header "User-Agent" \ # remove headers from the request
  --remove-header "Server"
```

#### Configuration Files
```yaml
tunnel: your-tunnel-name
credentials-file: /path/to/credentials.json

ingress:
  - hostname: "*.example.com"
    service: http://localhost:8000
    originRequest:
      headers:
        X-API-Key: "your-api-key"
        Authorization: "Bearer 123456789"
        X-Service-Name: "my-service"
      removeHeaders:
        - "User-Agent"
        - "Server"
  - service: http_status:404
```

### Testing
I have added test cases for the changes

### MISC
This is a optional change, and it does not break the exisiting functionallity. It is fully backward compatible.


I have also attached screenshots by creating tunnels with a simple nodejs server as a receiver.

Command
<img width="959" height="97" alt="image" src="https://github.com/user-attachments/assets/c573fb37-e43b-490a-9ecd-de7d770440cc" />

Server logs before using the remove headers flag
<img width="1491" height="575" alt="image" src="https://github.com/user-attachments/assets/a38b82a4-dc06-42cf-a06d-400eb42486f0" />

Server logs after using the remove headers flag
<img width="1451" height="507" alt="image" src="https://github.com/user-attachments/assets/03ba4aef-66a3-4860-9e34-e2fa76121f22" />

yaml config usage
<img width="1220" height="453" alt="image" src="https://github.com/user-attachments/assets/71ab5b1c-70b0-49d0-bf34-d5b8414d6c23" />

test cases
<img width="1026" height="236" alt="image" src="https://github.com/user-attachments/assets/35e9ed26-d8c5-4cc7-a4ea-b130c9bc584c" />
