### PR TITLE
Set systemd service start timeout to 30s

### DIFF
--- a/cmd/cloudflared/linux_service.go
+++ b/cmd/cloudflared/linux_service.go
@@ -60,7 +60,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-TimeoutStartSec=0
+TimeoutStartSec=30
 Type=notify
 ExecStart={{ .Path }} --no-autoupdate{{ range .ExtraArgs }} {{ . }}{{ end }}
 Restart=on-failure


### PR DESCRIPTION
This kills the hanging when there is a network issue (port blocking or no Internet) and the installation cannot be completed with no error sent to the output.

Before (killed manually since it hangs forever):

<img width="1089" height="92" alt="image" src="https://github.com/user-attachments/assets/de9003f9-4aaa-4667-9495-1d4b01069bed" />

After:

<img width="1099" height="104" alt="image" src="https://github.com/user-attachments/assets/f031035f-1633-46c0-a896-d9fd37054e83" />

---

Alternatively I can also set the context within `runApp` to terminate after X seconds, but if we leverage systemd, better using its native implementation instead.