### PR TITLE
Prevent loading the origin certificate for remotely-managed tunnels

### DIFF
--- a/cmd/cloudflared/tunnel/cmd.go
+++ b/cmd/cloudflared/tunnel/cmd.go
@@ -459,9 +459,10 @@ func StartServer(
 		}
 	}
 
-	userCreds, err := credentials.Read(c.String(cfdflags.OriginCert), log)
 	var isFEDEndpoint bool
-	if err != nil {
+	if c.String(TunnelTokenFlag) != "" || c.String(TunnelTokenFileFlag) != "" {
+		isFEDEndpoint = false
+	} else if userCreds, err := credentials.Read(c.String(cfdflags.OriginCert), log); err != nil {
 		isFEDEndpoint = false
 	} else {
 		isFEDEndpoint = userCreds.IsFEDEndpoint()


### PR DESCRIPTION
When running tunnels, an error log is output stating that the origin certificate cannot be found, even though it is not required for remotely managed tunnels.
This pull request modifies the behavior so that if a tunnel token is specified, the origin certificate will not be loaded.

Related to #1037.