### PR TITLE
cfapi: use strings.Builder to avoid quadratic complexity

### DIFF
--- a/cfapi/base_client.go
+++ b/cfapi/base_client.go
@@ -207,9 +207,11 @@ func (r *response) checkErrors() error {
 		return r.Errors[0]
 	}
 	var messages string
+	var messagesSb210 strings.Builder
 	for _, e := range r.Errors {
-		messages += fmt.Sprintf("%s; ", e)
+		messagesSb210.WriteString(fmt.Sprintf("%s; ", e))
 	}
+	messages += messagesSb210.String()
 	return fmt.Errorf("API errors: %s", messages)
 }
 


### PR DESCRIPTION
Poc reported and assessed not a security issue at https://hackerone.com/bugs?subject=user&report_id=3378933
```
package main

import (
	"strings"

	"fmt"
	"log"
	"net/http"
	"os"
	"runtime/pprof"

	"github.com/cloudflare/cloudflared/cfapi"
)

func main() {
	// just set up profiling
	f, err := os.Create("toto.cpu")
	if err != nil {
		log.Fatal("could not create CPU profile: ", err)
	}
	defer f.Close() // error handling omitted for example
	if err := pprof.StartCPUProfile(f); err != nil {
		log.Fatal("could not start CPU profile: ", err)
	}
	defer pprof.StopCPUProfile()

	// evil server
	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		content := `{"errors":[` + strings.Repeat(`{"code":1,"message":"a"},`, 0x10000) + `{"code":1,"message":"a"}]}`
		_, _ = w.Write([]byte(content))
		w.WriteHeader(http.StatusUnauthorized)
		w.Header().Set("Content-Type", "application/json")
	})
	server := &http.Server{
		Addr:    "127.0.0.1:8001",
		Handler: handler,
	}
	go server.ListenAndServe()

	// client being targetted
	client, err := cfapi.NewRESTClient("http://127.0.0.1:8001/", "", "", "", "", nil)
	fmt.Printf("lol %s\n", err)
	_, err = client.CreateTunnel("tunnel", []byte("secret"))
	fmt.Printf("lol %s\n", err)
}
```