### PR TITLE
Docker: use debian13 in the final image and update golang builder to 1.25.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # use a builder image for building cloudflare
 ARG TARGET_GOOS
 ARG TARGET_GOARCH
-FROM golang:1.24.9 AS builder
+FROM golang:1.25.5 AS builder
 ENV GO111MODULE=on \
   CGO_ENABLED=0 \
   TARGET_GOOS=${TARGET_GOOS} \
@@ -20,7 +20,7 @@ COPY . .
 RUN make cloudflared
 
 # use a distroless base image with glibc
-FROM gcr.io/distroless/base-debian12:nonroot
+FROM gcr.io/distroless/base-debian13:nonroot
 
 LABEL org.opencontainers.image.source="https://github.com/cloudflare/cloudflared"
 

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,5 +1,5 @@
 # use a builder image for building cloudflare
-FROM golang:1.24.9 AS builder
+FROM golang:1.25.5 AS builder
 ENV GO111MODULE=on \
   CGO_ENABLED=0 \
   # the CONTAINER_BUILD envvar is used set github.com/cloudflare/cloudflared/metrics.Runtime=virtual
@@ -15,7 +15,7 @@ COPY . .
 RUN GOOS=linux GOARCH=amd64 make cloudflared
 
 # use a distroless base image with glibc
-FROM gcr.io/distroless/base-debian12:nonroot
+FROM gcr.io/distroless/base-debian13:nonroot
 
 LABEL org.opencontainers.image.source="https://github.com/cloudflare/cloudflared"
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,5 +1,5 @@
 # use a builder image for building cloudflare
-FROM golang:1.24.9 AS builder
+FROM golang:1.25.5 AS builder
 ENV GO111MODULE=on \
   CGO_ENABLED=0 \
   # the CONTAINER_BUILD envvar is used set github.com/cloudflare/cloudflared/metrics.Runtime=virtual
@@ -15,7 +15,7 @@ COPY . .
 RUN GOOS=linux GOARCH=arm64 make cloudflared
 
 # use a distroless base image with glibc
-FROM gcr.io/distroless/base-debian12:nonroot-arm64
+FROM gcr.io/distroless/base-debian13:nonroot-arm64
 
 LABEL org.opencontainers.image.source="https://github.com/cloudflare/cloudflared"
 


### PR DESCRIPTION
It would make sense to upgrade to the latest stable Debian image (13 / Trixie) in the final stage.