### PR TITLE
Add --pidfile flag to access tcp command

### DIFF
--- a/cmd/cloudflared/access/cmd.go
+++ b/cmd/cloudflared/access/cmd.go
@@ -38,6 +38,7 @@ const (
 	sshGenCertFlag     = "short-lived-cert"
 	sshConnectTo       = "connect-to"
 	sshDebugStream     = "debug-stream"
+	sshPidFileFlag     = "pidfile"
 	sshConfigTemplate  = `
 Add to your {{.Home}}/.ssh/config:
 
@@ -203,6 +204,11 @@ func Commands() []*cli.Command {
 							Name:   sshDebugStream,
 							Hidden: true,
 							Usage:  "Writes up-to the max provided stream payloads to the logger as debug statements.",
+						},
+						&cli.StringFlag{
+							Name:    sshPidFileFlag,
+							Usage:   "Write the application's PID to this file",
+							EnvVars: []string{"TUNNEL_SERVICE_PIDFILE"},
 						},
 					},
 				},


### PR DESCRIPTION
This adds a `--pidfile` flag to the `cloudflared access tcp` command (also applies to the ssh/rdp/smb aliases).

  When specified, the process writes its PID to the given file path on startup. This makes it much easier to manage the process in scripts and CI/CD pipelines without resorting to fragile pgrep patterns.

  Usage looks like:

      cloudflared access tcp --hostname https://app.example.com --url 127.0.0.1:8080 --pidfile /var/run/cloudflared.pid &

      # later, clean shutdown
      kill $(cat /var/run/cloudflared.pid)

  Tilde expansion is supported for paths like `~/.cloudflared.pid`.

  The implementation follows the same pattern used by the existing `--pidfile` flag in the tunnel command, using go-homedir for path expansion and logging errors rather than failing hard if the pidfile can't be written.

  Closes #723