### PR TITLE
Add --pidfile support with signal-aware cleanup to cloudflared access…

### DIFF
--- a/cmd/cloudflared/access/carrier_test.go
+++ b/cmd/cloudflared/access/carrier_test.go
@@ -1,0 +1,53 @@
+package access
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWritePidFile(t *testing.T) {
+	log := zerolog.Nop()
+
+	t.Run("writes current PID to file", func(t *testing.T) {
+		pidFile := filepath.Join(t.TempDir(), "test.pid")
+
+		writePidFile(pidFile, &log)
+
+		content, err := os.ReadFile(pidFile)
+		require.NoError(t, err)
+
+		pid, err := strconv.Atoi(string(content))
+		require.NoError(t, err)
+		assert.Equal(t, os.Getpid(), pid)
+	})
+
+	t.Run("handles invalid path gracefully", func(t *testing.T) {
+		// Should not panic on a path that can't be created
+		writePidFile("/nonexistent/directory/test.pid", &log)
+	})
+}
+
+func TestRemovePidFile(t *testing.T) {
+	log := zerolog.Nop()
+
+	t.Run("removes existing pid file", func(t *testing.T) {
+		pidFile := filepath.Join(t.TempDir(), "test.pid")
+
+		writePidFile(pidFile, &log)
+		assert.FileExists(t, pidFile)
+
+		removePidFile(pidFile, &log)
+		assert.NoFileExists(t, pidFile)
+	})
+
+	t.Run("handles missing file gracefully", func(t *testing.T) {
+		// Should not panic when removing a file that doesn't exist
+		removePidFile("/tmp/nonexistent-cloudflared-test.pid", &log)
+	})
+}

--- a/cmd/cloudflared/access/cmd.go
+++ b/cmd/cloudflared/access/cmd.go
@@ -38,6 +38,7 @@ const (
 	sshGenCertFlag     = "short-lived-cert"
 	sshConnectTo       = "connect-to"
 	sshDebugStream     = "debug-stream"
+	sshPidFileFlag     = "pidfile"
 	sshConfigTemplate  = `
 Add to your {{.Home}}/.ssh/config:
 
@@ -203,6 +204,11 @@ func Commands() []*cli.Command {
 							Name:   sshDebugStream,
 							Hidden: true,
 							Usage:  "Writes up-to the max provided stream payloads to the logger as debug statements.",
+						},
+						&cli.StringFlag{
+							Name:    sshPidFileFlag,
+							Usage:   "Write the application's PID to this file after startup.",
+							EnvVars: []string{"TUNNEL_ACCESS_PIDFILE"},
 						},
 					},
 				},


### PR DESCRIPTION
## Summary

Adds `--pidfile` flag to `cloudflared access tcp` (and its aliases: `rdp`, `ssh`, `smb`).

- Writes the process PID to the specified file after startup
- **Cleans up the PID file on exit** — handles both graceful shutdown (`defer`) and signals (`SIGTERM`/`SIGINT`)
- Follows the same pattern as the tunnel command's existing `--pidfile` support
- Includes unit tests for both `writePidFile` and `removePidFile`

Closes #723

## How it differs from #1579

This PR improves on the existing attempt (#1579) with:
1. **Signal-aware PID file cleanup** — traps SIGTERM/SIGINT to remove the file before exiting, preventing stale PIDs when using `kill <pid>`
2. **Graceful shutdown cleanup** — `defer removePidFile()` covers error exits and normal shutdowns
3. **Unit tests** — new `carrier_test.go` with tests for write, cleanup, and error handling

## Test plan

- [x] `make fmt-check` passes
- [x] `make lint` passes
- [x] `make test` passes (including new unit tests)
- [x] `./cloudflared access tcp --help` shows the `--pidfile` flag
- [x] Manual test: PID file is written on startup and cleaned up on `kill`