### PR TITLE
feat: support multiple metrics addresses via repeated flag

### DIFF
--- a/cmd/cloudflared/tunnel/subcommands.go
+++ b/cmd/cloudflared/tunnel/subcommands.go
@@ -478,10 +478,11 @@ func buildReadyCommand() *cli.Command {
 }
 
 func readyCommand(c *cli.Context) error {
-	metricsOpts := c.String(flags.Metrics)
-	if !c.IsSet(flags.Metrics) {
+	metricsAddrs := c.StringSlice(flags.Metrics)
+	if len(metricsAddrs) == 0 {
 		return errors.New("--metrics has to be provided")
 	}
+	metricsOpts := metricsAddrs[0]
 
 	requestURL := fmt.Sprintf("http://%s/ready", metricsOpts)
 	req, err := http.NewRequest(http.MethodGet, requestURL, nil)

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -13,28 +13,49 @@ import (
 func TestMetricsListenerCreation(t *testing.T) {
 	t.Parallel()
 	listeners := gracenet.Net{}
-	listener1, err := metrics.CreateMetricsListener(&listeners, metrics.GetMetricsDefaultAddress("host"))
+	ls1, err := metrics.CreateMetricsListener(&listeners, []string{metrics.GetMetricsDefaultAddress("host")})
+	require.NoError(t, err)
+	require.Len(t, ls1, 1)
+	listener1 := ls1[0]
 	assert.Equal(t, "127.0.0.1:20241", listener1.Addr().String())
+
+	ls2, err := metrics.CreateMetricsListener(&listeners, []string{metrics.GetMetricsDefaultAddress("host")})
 	require.NoError(t, err)
-	listener2, err := metrics.CreateMetricsListener(&listeners, metrics.GetMetricsDefaultAddress("host"))
+	require.Len(t, ls2, 1)
+	listener2 := ls2[0]
 	assert.Equal(t, "127.0.0.1:20242", listener2.Addr().String())
+
+	ls3, err := metrics.CreateMetricsListener(&listeners, []string{metrics.GetMetricsDefaultAddress("host")})
 	require.NoError(t, err)
-	listener3, err := metrics.CreateMetricsListener(&listeners, metrics.GetMetricsDefaultAddress("host"))
+	require.Len(t, ls3, 1)
+	listener3 := ls3[0]
 	assert.Equal(t, "127.0.0.1:20243", listener3.Addr().String())
+
+	ls4, err := metrics.CreateMetricsListener(&listeners, []string{metrics.GetMetricsDefaultAddress("host")})
 	require.NoError(t, err)
-	listener4, err := metrics.CreateMetricsListener(&listeners, metrics.GetMetricsDefaultAddress("host"))
+	require.Len(t, ls4, 1)
+	listener4 := ls4[0]
 	assert.Equal(t, "127.0.0.1:20244", listener4.Addr().String())
+
+	ls5, err := metrics.CreateMetricsListener(&listeners, []string{metrics.GetMetricsDefaultAddress("host")})
 	require.NoError(t, err)
-	listener5, err := metrics.CreateMetricsListener(&listeners, metrics.GetMetricsDefaultAddress("host"))
+	require.Len(t, ls5, 1)
+	listener5 := ls5[0]
 	assert.Equal(t, "127.0.0.1:20245", listener5.Addr().String())
+
+	ls6, err := metrics.CreateMetricsListener(&listeners, []string{metrics.GetMetricsDefaultAddress("host")})
 	require.NoError(t, err)
-	listener6, err := metrics.CreateMetricsListener(&listeners, metrics.GetMetricsDefaultAddress("host"))
+	require.Len(t, ls6, 1)
+	listener6 := ls6[0]
 	addresses := [5]string{"127.0.0.1:20241", "127.0.0.1:20242", "127.0.0.1:20243", "127.0.0.1:20244", "127.0.0.1:20245"}
 	assert.NotContains(t, addresses, listener6.Addr().String())
+
+	ls7, err := metrics.CreateMetricsListener(&listeners, []string{"localhost:12345"})
 	require.NoError(t, err)
-	listener7, err := metrics.CreateMetricsListener(&listeners, "localhost:12345")
+	require.Len(t, ls7, 1)
+	listener7 := ls7[0]
 	assert.Equal(t, "127.0.0.1:12345", listener7.Addr().String())
-	require.NoError(t, err)
+
 	err = listener1.Close()
 	require.NoError(t, err)
 	err = listener2.Close()
@@ -48,5 +69,15 @@ func TestMetricsListenerCreation(t *testing.T) {
 	err = listener6.Close()
 	require.NoError(t, err)
 	err = listener7.Close()
+	require.NoError(t, err)
+
+	ls8, err := metrics.CreateMetricsListener(&listeners, []string{"127.0.0.1:12346", "127.0.0.1:12347"})
+	require.NoError(t, err)
+	require.Len(t, ls8, 2)
+	assert.Equal(t, "127.0.0.1:12346", ls8[0].Addr().String())
+	assert.Equal(t, "127.0.0.1:12347", ls8[1].Addr().String())
+	err = ls8[0].Close()
+	require.NoError(t, err)
+	err = ls8[1].Close()
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary
This PR updates the `--metrics` flag to accept multiple values, allowing the metrics server to bind to specific addresses (e.g., localhost IPv4 and IPv6) without exposing the endpoint to all interfaces via `[::]`.

## Changes
-   **CLI:** Changed `metrics` flag to `StringSliceFlag`. Users can now pass `--metrics` multiple times.
-   **Metrics Package:**
    -   `CreateMetricsListener` now accepts a slice of addresses and returns a slice of listeners.
    -   `ServeMetrics` now accepts a slice of listeners and serves them concurrently using a shared `http.Server`.
-   **Tunnel Command:**
    -   `StartServer` updated to initialize and close multiple listeners.
    -   `readyCommand` updated to check the first configured metrics address.
-   **Tests:** Added test cases for multiple listener creation.

## How to test
Run the tunnel with multiple metrics flags:
```bash
cloudflared tunnel run --metrics 127.0.0.1:2020 --metrics [::1]:2020 ...
```
Verify that the metrics endpoint is accessible on both addresses but not on external interfaces.
