### PR TITLE
supervisor: accept Orchestrator interface instead of concrete type

### DIFF
--- a/connection/connection.go
+++ b/connection/connection.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
+	cfdflow "github.com/cloudflare/cloudflared/flow"
 	"github.com/cloudflare/cloudflared/tracing"
 	"github.com/cloudflare/cloudflared/tunnelrpc/pogs"
 	"github.com/cloudflare/cloudflared/websocket"
@@ -53,6 +54,7 @@ type Orchestrator interface {
 	UpdateConfig(version int32, config []byte) *pogs.UpdateConfigurationResponse
 	GetConfigJSON() ([]byte, error)
 	GetOriginProxy() (OriginProxy, error)
+	GetFlowLimiter() cfdflow.Limiter
 }
 
 type TunnelProperties struct {

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -63,6 +63,10 @@ func (mcr *mockOrchestrator) GetOriginProxy() (OriginProxy, error) {
 	return mcr.originProxy, nil
 }
 
+func (*mockOrchestrator) GetFlowLimiter() cfdflow.Limiter {
+	return nil
+}
+
 func (mcr *mockOrchestrator) WarpRoutingEnabled() (enabled bool) {
 	return true
 }

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/cloudflare/cloudflared/connection"
 	"github.com/cloudflare/cloudflared/edgediscovery"
-	"github.com/cloudflare/cloudflared/orchestration"
 	v3 "github.com/cloudflare/cloudflared/quic/v3"
 	"github.com/cloudflare/cloudflared/retry"
 	"github.com/cloudflare/cloudflared/signal"
@@ -31,7 +30,7 @@ const (
 // reconnects them if they disconnect.
 type Supervisor struct {
 	config                  *TunnelConfig
-	orchestrator            *orchestration.Orchestrator
+	orchestrator            connection.Orchestrator
 	edgeIPs                 *edgediscovery.Edge
 	edgeTunnelServer        TunnelServer
 	tunnelErrors            chan tunnelError
@@ -56,7 +55,7 @@ type tunnelError struct {
 	err   error
 }
 
-func NewSupervisor(config *TunnelConfig, orchestrator *orchestration.Orchestrator, reconnectCh chan ReconnectSignal, gracefulShutdownC <-chan struct{}) (*Supervisor, error) {
+func NewSupervisor(config *TunnelConfig, orchestrator connection.Orchestrator, reconnectCh chan ReconnectSignal, gracefulShutdownC <-chan struct{}) (*Supervisor, error) {
 	isStaticEdge := len(config.EdgeAddrs) > 0
 
 	var err error

--- a/supervisor/tunnel.go
+++ b/supervisor/tunnel.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cloudflare/cloudflared/ingress"
 	"github.com/cloudflare/cloudflared/ingress/origins"
 	"github.com/cloudflare/cloudflared/management"
-	"github.com/cloudflare/cloudflared/orchestration"
 	quicpogs "github.com/cloudflare/cloudflared/quic"
 	v3 "github.com/cloudflare/cloudflared/quic/v3"
 	"github.com/cloudflare/cloudflared/retry"
@@ -86,7 +85,7 @@ func (c *TunnelConfig) connectionOptions(originLocalAddr string, previousAttempt
 func StartTunnelDaemon(
 	ctx context.Context,
 	config *TunnelConfig,
-	orchestrator *orchestration.Orchestrator,
+	orchestrator connection.Orchestrator,
 	connectedSignal *signal.Signal,
 	reconnectCh chan ReconnectSignal,
 	graceShutdownC <-chan struct{},
@@ -168,7 +167,7 @@ func (f *ipAddrFallback) ShouldGetNewAddress(connIndex uint8, err error) (needsN
 
 type EdgeTunnelServer struct {
 	config            *TunnelConfig
-	orchestrator      *orchestration.Orchestrator
+	orchestrator      connection.Orchestrator
 	sessionManager    v3.SessionManager
 	datagramMetrics   v3.Metrics
 	edgeAddrHandler   EdgeAddrHandler


### PR DESCRIPTION
Hi :wave: 

This project is pretty cool! Thank you very much for it :pray: 

I'm filing this PR to make the Go code here a bit more extensible. If we accept the `connection.Orchestrator` interface instead of the `*orchestration.Orchestrator` concrete type in the places I have changed in this PR I would be able to reuse some of this code in another project that imports this one. Please let me know if this is okay :pray: 