### PR TITLE
feat: add --pidfile support for access subcommand

### DIFF
--- a/cmd/cloudflared/access/carrier.go
+++ b/cmd/cloudflared/access/carrier.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/urfave/cli/v2"
@@ -68,6 +70,21 @@ func ssh(c *cli.Context) error {
 		outputTerminal = logger.EnableTerminalLog
 	}
 	log := logger.CreateSSHLoggerFromContext(c, outputTerminal)
+
+	if pidFile := c.String(sshPidFileFlag); pidFile != "" {
+		expandedPidFile, err := homedir.Expand(pidFile)
+		if err != nil {
+			log.Err(err).Msg("unable to expand pidfile path")
+		} else if err := writePidFile(expandedPidFile, log); err != nil {
+			log.Err(err).Msg("failed to write pidfile")
+		} else {
+			defer func() {
+				if err := os.Remove(expandedPidFile); err != nil {
+					log.Err(err).Msg("failed to remove pidfile")
+				}
+			}()
+		}
+	}
 
 	// get the hostname from the cmdline and error out if its not provided
 	rawHostName := c.String(sshHostnameFlag)
@@ -144,4 +161,18 @@ func ssh(c *cli.Context) error {
 		s = stream.NewDebugStream(s, &logger, maxMessages)
 	}
 	return carrier.StartClient(wsConn, s, options)
+}
+
+// writePidFile writes the current process ID to the given path.
+func writePidFile(path string, log *zerolog.Logger) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("unable to create pidfile %q: %w", path, err)
+	}
+	defer file.Close()
+	if _, err := fmt.Fprintf(file, "%d", os.Getpid()); err != nil {
+		return fmt.Errorf("unable to write pid to %q: %w", path, err)
+	}
+	log.Info().Str("pidfile", path).Msg("wrote pidfile")
+	return nil
 }

--- a/cmd/cloudflared/access/cmd.go
+++ b/cmd/cloudflared/access/cmd.go
@@ -38,6 +38,7 @@ const (
 	sshGenCertFlag     = "short-lived-cert"
 	sshConnectTo       = "connect-to"
 	sshDebugStream     = "debug-stream"
+	sshPidFileFlag     = "pidfile"
 	sshConfigTemplate  = `
 Add to your {{.Home}}/.ssh/config:
 
@@ -203,6 +204,11 @@ func Commands() []*cli.Command {
 							Name:   sshDebugStream,
 							Hidden: true,
 							Usage:  "Writes up-to the max provided stream payloads to the logger as debug statements.",
+						},
+						&cli.StringFlag{
+							Name:    sshPidFileFlag,
+							Usage:   "Write the application's PID to this file after startup.",
+							EnvVars: []string{"TUNNEL_PIDFILE"},
 						},
 					},
 				},


### PR DESCRIPTION
## Summary

Add `--pidfile` support to the `cloudflared access tcp` (and its aliases `ssh`, `rdp`, `smb`) subcommand.

Closes #723

## Problem

The `--pidfile` flag works for `cloudflared tunnel` but not for `cloudflared access` subcommands. Users running `cloudflared access tcp` as a daemon need pidfile support for process management with systemd, launchd, or custom init scripts.

## Solution

- Register the `--pidfile` flag on the `access tcp` subcommand (also exposed via `TUNNEL_PIDFILE` env var, matching the tunnel command)
- Write the PID file immediately on startup
- Clean up (remove) the PID file on exit via `defer`
- Reuse the same `go-homedir` path expansion already used by the tunnel pidfile implementation

The implementation is intentionally minimal — it follows the same pattern as the existing tunnel `--pidfile` support.

## Usage

```bash
# Start an access TCP forwarder with pidfile
cloudflared access tcp --hostname example.com --url localhost:2222 --pidfile /var/run/cloudflared-access.pid

# Works with systemd for daemon management
# PIDFile=/var/run/cloudflared-access.pid in your .service unit

# Also works via environment variable
TUNNEL_PIDFILE=/var/run/cloudflared-access.pid cloudflared access ssh --hostname example.com
```

## Changes

- `cmd/cloudflared/access/cmd.go` — added `pidfile` flag constant and registered the flag on the `tcp` subcommand
- `cmd/cloudflared/access/carrier.go` — added pidfile write on startup with deferred cleanup on exit