### PR TITLE
Fix: cloudflared access token invalidates JWT signature by re-serializing the header

### DIFF
--- a/token/token.go
+++ b/token/token.go
@@ -400,7 +400,7 @@ func GetOrgTokenIfExists(authDomain string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	token, err := getTokenIfExists(path)
+	raw, token, err := getTokenIfExists(path)
 	if err != nil {
 		return "", err
 	}
@@ -414,7 +414,7 @@ func GetOrgTokenIfExists(authDomain string) (string, error) {
 		err := os.Remove(path)
 		return "", err
 	}
-	return token.CompactSerialize()
+	return raw, nil
 }
 
 func GetAppTokenIfExists(appInfo *AppInfo) (string, error) {
@@ -422,7 +422,7 @@ func GetAppTokenIfExists(appInfo *AppInfo) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	token, err := getTokenIfExists(path)
+	raw, token, err := getTokenIfExists(path)
 	if err != nil {
 		return "", err
 	}
@@ -436,20 +436,24 @@ func GetAppTokenIfExists(appInfo *AppInfo) (string, error) {
 		err := os.Remove(path)
 		return "", err
 	}
-	return token.CompactSerialize()
+	return raw, nil
 }
 
-// GetTokenIfExists will return the token from local storage if it exists and not expired
-func getTokenIfExists(path string) (*jose.JSONWebSignature, error) {
+// getTokenIfExists will return the token from local storage if it exists and not expired.
+// It returns both the raw token string (as stored on disk) and the parsed JWS object.
+// Callers should use the raw string when returning the token to preserve the original
+// serialization and avoid invalidating the JWT signature.
+func getTokenIfExists(path string) (string, *jose.JSONWebSignature, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
-	token, err := jose.ParseSigned(string(content), signatureAlgs)
+	raw := strings.TrimSpace(string(content))
+	token, err := jose.ParseSigned(raw, signatureAlgs)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
-	return token, nil
+	return raw, token, nil
 }
 
 // RemoveTokenIfExists removes the a token from local storage if it exists

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -1,10 +1,16 @@
 package token
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHandleRedirects_AttachOrgToken(t *testing.T) {
@@ -132,4 +138,83 @@ func TestJwtPayloadUnmarshal_FailsWhenAudIsOmitted(t *testing.T) {
 	if err.Error() != wantErr {
 		t.Errorf("Expected %v, got %v", wantErr, err)
 	}
+}
+
+// craftTestToken builds a compact JWS string from the given raw JSON header,
+// payload, and fake signature bytes. This lets tests control exact header key
+// ordering.
+func craftTestToken(header, payload, sig string) string {
+	h := base64.RawURLEncoding.EncodeToString([]byte(header))
+	p := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	s := base64.RawURLEncoding.EncodeToString([]byte(sig))
+	return h + "." + p + "." + s
+}
+
+func TestGetTokenIfExists_PreservesOriginalTokenString(t *testing.T) {
+	t.Parallel()
+
+	// Header with non-alphabetical key ordering: "typ" before "alg".
+	// go-jose's CompactSerialize() re-marshals header JSON with Go's default
+	// alphabetical key order ("alg" before "typ"), producing different base64url
+	// bytes and invalidating the JWT signature.
+	header := `{"typ":"JWT","alg":"RS256"}`
+	payload := `{"aud":"test-aud","exp":9999999999,"iat":1,"nbf":1,"sub":"test","email":"test@test.com","iss":"test"}`
+	originalToken := craftTestToken(header, payload, "fake-sig")
+
+	tmpFile := filepath.Join(t.TempDir(), "test-token")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(originalToken), 0600))
+
+	raw, token, err := getTokenIfExists(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, token)
+
+	// The returned raw string must be byte-for-byte identical to what was on disk.
+	assert.Equal(t, originalToken, raw)
+
+	// CompactSerialize() re-encodes the header with alphabetical keys, which
+	// produces a different string — exactly the bug this change fixes.
+	reserialized, err := token.CompactSerialize()
+	require.NoError(t, err)
+	assert.NotEqual(t, originalToken, reserialized,
+		"CompactSerialize() reorders header keys, which would invalidate the JWT signature")
+}
+
+func TestGetTokenIfExists_TrimsWhitespace(t *testing.T) {
+	t.Parallel()
+
+	header := `{"alg":"RS256"}`
+	payload := `{"aud":"test-aud","exp":9999999999,"iat":1,"nbf":1,"sub":"test","email":"test@test.com","iss":"test"}`
+	token := craftTestToken(header, payload, "fake-sig")
+
+	// Simulate a file with trailing newline/whitespace (common with text editors).
+	tokenWithWhitespace := "  " + token + "  \n"
+	tmpFile := filepath.Join(t.TempDir(), "test-token-ws")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(tokenWithWhitespace), 0600))
+
+	raw, parsed, err := getTokenIfExists(tmpFile)
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+
+	assert.Equal(t, token, raw, "raw token should have surrounding whitespace trimmed")
+}
+
+func TestGetTokenIfExists_FileNotFound(t *testing.T) {
+	t.Parallel()
+
+	raw, token, err := getTokenIfExists(filepath.Join(t.TempDir(), "nonexistent"))
+	assert.Error(t, err)
+	assert.Empty(t, raw)
+	assert.Nil(t, token)
+}
+
+func TestGetTokenIfExists_InvalidToken(t *testing.T) {
+	t.Parallel()
+
+	tmpFile := filepath.Join(t.TempDir(), "bad-token")
+	require.NoError(t, os.WriteFile(tmpFile, []byte("not-a-valid-jws"), 0600))
+
+	raw, token, err := getTokenIfExists(tmpFile)
+	assert.Error(t, err)
+	assert.Empty(t, raw)
+	assert.Nil(t, token)
 }


### PR DESCRIPTION
## Summary

`getTokenIfExists` reads the cached JWT from disk, parses it with `jose.ParseSigned()`, and callers (`GetAppTokenIfExists` / `GetOrgTokenIfExists`) return `token.CompactSerialize()`. This re-serializes the JWT header with Go's default alphabetical key ordering ([documented behavior of `json.Marshal` on maps](https://pkg.go.dev/encoding/json#Marshal:~:text=Map%20values%20encode,converted%20to%20strings)), which differs from the original key order. Since the JWT signature covers the exact base64url-encoded header bytes, the re-ordered header invalidates the signature.

### Root cause in go-jose

[`CompactSerialize`](https://github.com/go-jose/go-jose/blob/d50302948f33c6365a8aa2d690dae02ebdd548a5/jws.go#L441) delegates to compact serialization, and [`compactSerialize`](https://github.com/go-jose/go-jose/blob/d50302948f33c6365a8aa2d690dae02ebdd548a5/jws.go#L426) calls [`mustSerializeJSON(obj.Signatures[0].protected)`](https://github.com/go-jose/go-jose/blob/d50302948f33c6365a8aa2d690dae02ebdd548a5/jws.go#L426). [`mustSerializeJSON`](https://github.com/go-jose/go-jose/blob/d50302948f33c6365a8aa2d690dae02ebdd548a5/encoding.go#L35-L39) in turn calls [`json.Marshal`](https://github.com/go-jose/go-jose/blob/d50302948f33c6365a8aa2d690dae02ebdd548a5/encoding.go#L36).

The protected header is stored as [`rawHeader`](https://github.com/go-jose/go-jose/blob/d50302948f33c6365a8aa2d690dae02ebdd548a5/shared.go#L186), which is a `map[HeaderKey]*json.RawMessage`. Go's `json.Marshal` sorts map keys alphabetically, so `{"typ":"JWT","alg":"RS256"}` becomes `{"alg":"RS256","typ":"JWT"}` — different base64url bytes, broken signature.

Notably, go-jose *does* preserve the original protected-header bytes when parsing: [`signature.original` is assigned from `parsed.Protected`](https://github.com/go-jose/go-jose/blob/d50302948f33c6365a8aa2d690dae02ebdd548a5/jws.go#L271-L275). And during signature verification, [`computeAuthData`](https://github.com/go-jose/go-jose/blob/d50302948f33c6365a8aa2d690dae02ebdd548a5/jws.go#L147-L160) correctly checks [`signature.original.Protected`](https://github.com/go-jose/go-jose/blob/d50302948f33c6365a8aa2d690dae02ebdd548a5/jws.go#L152) and uses the original bytes via [`.base64()`](https://github.com/go-jose/go-jose/blob/d50302948f33c6365a8aa2d690dae02ebdd548a5/jws.go#L156). But [`compactSerialize`](https://github.com/go-jose/go-jose/blob/d50302948f33c6365a8aa2d690dae02ebdd548a5/jws.go#L426) ignores `signature.original` entirely and re-marshals from the map.

## Changes

- **`getTokenIfExists`**: Returns `(string, *jose.JSONWebSignature, error)` instead of `(*jose.JSONWebSignature, error)`. The raw token string (trimmed) is read from disk and returned alongside the parsed JWS (still needed for expiry checking).
- **`GetAppTokenIfExists` / `GetOrgTokenIfExists`**: Return the raw string instead of calling `token.CompactSerialize()`.

## Tests

Four new tests in `token/token_test.go`:

| Test | Verifies |
|------|----------|
| `TestGetTokenIfExists_PreservesOriginalTokenString` | Raw string matches disk; `CompactSerialize()` produces a different (broken) string |
| `TestGetTokenIfExists_TrimsWhitespace` | Leading/trailing whitespace is stripped from the raw token |
| `TestGetTokenIfExists_FileNotFound` | Error path when file doesn't exist |
| `TestGetTokenIfExists_InvalidToken` | Error path when file contains unparseable content |

The core regression test (`PreservesOriginalTokenString`) crafts a JWS with non-alphabetical header key order and asserts that `CompactSerialize()` would produce a different string — directly demonstrating the bug.


```
go test ./token/... -v
--- PASS: TestGetTokenIfExists_PreservesOriginalTokenString
--- PASS: TestGetTokenIfExists_TrimsWhitespace
--- PASS: TestGetTokenIfExists_FileNotFound
--- PASS: TestGetTokenIfExists_InvalidToken
PASS
```

> **Disclaimer**
> I used AI assistance (Opus 4.6) to help generate and validate this change. I do not have prior Go experience, so I also manually reviewed the resulting code and tests in my limited capacity. From that review, the change looks correct to me and the test coverage appears to exercise the bug and the fix clearly.