### PR TITLE
Fix HA connection metric for failed tunnel dials

### DIFF
--- a/supervisor/fuse.go
+++ b/supervisor/fuse.go
@@ -26,7 +26,7 @@ func (f *booleanFuse) Value() bool {
 	return f.value == 1
 }
 
-func (f *booleanFuse) Fuse(result bool) {
+func (f *booleanFuse) Fuse(result bool) bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	newValue := int32(2)
@@ -36,7 +36,9 @@ func (f *booleanFuse) Fuse(result bool) {
 	if f.value == 0 {
 		f.value = newValue
 		f.cond.Broadcast()
+		return true
 	}
+	return false
 }
 
 // Await blocks until Fuse has been called at least once.

--- a/supervisor/tunnel.go
+++ b/supervisor/tunnel.go
@@ -186,10 +186,12 @@ type TunnelServer interface {
 }
 
 func (e *EdgeTunnelServer) Serve(ctx context.Context, connIndex uint8, protocolFallback *protocolFallback, connectedSignal *signal.Signal) error {
-	haConnections.Inc()
-	defer haConnections.Dec()
-
 	connectedFuse := newBooleanFuse()
+	defer func() {
+		if connectedFuse.Value() {
+			haConnections.Dec()
+		}
+	}()
 	go func() {
 		if connectedFuse.Await() {
 			connectedSignal.Notify()
@@ -702,7 +704,9 @@ type connectedFuse struct {
 }
 
 func (cf *connectedFuse) Connected() {
-	cf.fuse.Fuse(true)
+	if cf.fuse.Fuse(true) {
+		haConnections.Inc()
+	}
 	cf.backoff.reset()
 }
 

--- a/supervisor/tunnel_test.go
+++ b/supervisor/tunnel_test.go
@@ -4,9 +4,11 @@ import (
 	"testing"
 	"time"
 
+	dto "github.com/prometheus/client_model/go"
 	"github.com/quic-go/quic-go"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cloudflare/cloudflared/connection"
 	"github.com/cloudflare/cloudflared/edgediscovery"
@@ -16,6 +18,40 @@ import (
 type dynamicMockFetcher struct {
 	protocolPercents edgediscovery.ProtocolPercents
 	err              error
+}
+
+func TestConnectedFuseUpdatesHAConnectionsOnce(t *testing.T) {
+	fuse := newBooleanFuse()
+	connectedFuse := &connectedFuse{
+		fuse: fuse,
+		backoff: &protocolFallback{
+			BackoffHandler: retry.NewBackoff(3, time.Millisecond, false),
+		},
+	}
+	initial := haConnectionsValue(t)
+	defer haConnections.Set(initial)
+
+	connectedFuse.Connected()
+	assert.Equal(t, initial+1, haConnectionsValue(t))
+
+	connectedFuse.Connected()
+	assert.Equal(t, initial+1, haConnectionsValue(t))
+}
+
+func TestUnconnectedFuseDoesNotUpdateHAConnections(t *testing.T) {
+	initial := haConnectionsValue(t)
+	defer haConnections.Set(initial)
+
+	fuse := newBooleanFuse()
+	fuse.Fuse(false)
+
+	assert.Equal(t, initial, haConnectionsValue(t))
+}
+
+func haConnectionsValue(t *testing.T) float64 {
+	var metric dto.Metric
+	require.NoError(t, haConnections.Write(&metric))
+	return metric.GetGauge().GetValue()
 }
 
 func (dmf *dynamicMockFetcher) fetch() edgediscovery.PercentageFetcher {


### PR DESCRIPTION
## Summary
- count `cloudflared_tunnel_ha_connections` only after a tunnel connection successfully registers with the edge
- avoid incrementing the active HA gauge for failed dial or registration attempts
- add focused supervisor tests for connected and unconnected fuse behavior

Fixes #1633.

## Testing
- `git diff --check`
- `go test -mod=vendor ./supervisor`
- `go test -mod=vendor ./supervisor ./connection`
- `go test -mod=vendor ./...` (local environment failure limited to `ingress` ICMP tests because this container cannot create the required ping/raw sockets: GID 1000 is outside `ping_group_range` and ICMPv6 socket creation is denied)
