### PR TITLE
token: validate response host in GetAppInfo before trusting AppInfo headers

### DIFF
--- a/token/token.go
+++ b/token/token.go
@@ -23,7 +23,22 @@ const (
 	appAUDHeader               = "CF-Access-Aud"
 	AccessLoginWorkerPath      = "/cdn-cgi/access/login"
 	AccessAuthorizedWorkerPath = "/cdn-cgi/access/authorized"
+	cloudflareAccessSuffix     = ".cloudflareaccess.com"
 )
+
+// isCloudflareAccessHost reports whether host is a Cloudflare Access team
+// hostname (*.cloudflareaccess.com). Used by GetAppInfo to verify that a
+// response carrying CF-Access-Domain / CF-Access-Aud values actually came
+// from the Cloudflare Access edge rather than from whatever host the user
+// originally invoked cloudflared against.
+func isCloudflareAccessHost(host string) bool {
+	// Drop a trailing port if present.
+	if i := strings.IndexByte(host, ':'); i >= 0 {
+		host = host[:i]
+	}
+	host = strings.ToLower(host)
+	return strings.HasSuffix(host, cloudflareAccessSuffix) && len(host) > len(cloudflareAccessSuffix)
+}
 
 var (
 	userAgent     = "DEV"
@@ -385,6 +400,15 @@ func GetAppInfo(reqURL *url.URL) (*AppInfo, error) {
 	var aud string
 	location := resp.Request.URL
 	if strings.Contains(location.Path, AccessLoginWorkerPath) {
+		// The redirect chain stopped at a URL whose path matches the
+		// AccessLoginWorkerPath substring. That predicate alone does not
+		// guarantee the response actually came from Cloudflare — any host can
+		// expose a /cdn-cgi/access/login path. Verify the host belongs to the
+		// Cloudflare Access edge (*.cloudflareaccess.com) before treating
+		// CF-Access-Domain and the ?kid= query parameter as authoritative.
+		if !isCloudflareAccessHost(location.Hostname()) {
+			return nil, fmt.Errorf("AppInfo redirect endpoint served by non-Cloudflare host %q; refusing to trust response headers", location.Hostname())
+		}
 		aud = resp.Request.URL.Query().Get("kid")
 		if aud == "" {
 			return nil, errors.New("Empty app aud")

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -3,7 +3,9 @@ package token
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -131,5 +133,64 @@ func TestJwtPayloadUnmarshal_FailsWhenAudIsOmitted(t *testing.T) {
 	wantErr := "aud field is not a string or an array of strings"
 	if err.Error() != wantErr {
 		t.Errorf("Expected %v, got %v", wantErr, err)
+	}
+}
+
+func TestIsCloudflareAccessHost(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"team.cloudflareaccess.com", true},
+		{"team.cloudflareaccess.com:8443", true},
+		{"TEAM.cloudflareaccess.com", true},
+		{"sub.team.cloudflareaccess.com", true},
+		{"cloudflareaccess.com", false},
+		{".cloudflareaccess.com", false},
+		{"attacker.com", false},
+		{"127.0.0.1", false},
+		{"127.0.0.1:8080", false},
+		{"cloudflareaccess.com.attacker.com", false},
+		{"team-cloudflareaccess.com", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isCloudflareAccessHost(c.host); got != c.want {
+			t.Errorf("isCloudflareAccessHost(%q) = %v, want %v", c.host, got, c.want)
+		}
+	}
+}
+
+func TestGetAppInfo_RejectsRedirectFromNonCloudflareHost(t *testing.T) {
+	// Stand up a server that mimics the attacker shape: a HEAD to /
+	// redirects to /cdn-cgi/access/login?kid=AUD on the same host, which
+	// returns 200 with CF-Access-Domain set. Without host validation, the
+	// (AppDomain, AppAUD) fields would come from this attacker-controlled
+	// response. With host validation, GetAppInfo must refuse it.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			http.Redirect(w, r, "/cdn-cgi/access/login?kid=AUD123", http.StatusFound)
+			return
+		}
+		if strings.Contains(r.URL.Path, AccessLoginWorkerPath) {
+			w.Header().Set(appDomainHeader, "victim-app.example.com")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	reqURL, err := url.Parse(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+
+	appInfo, err := GetAppInfo(reqURL)
+	if err == nil {
+		t.Fatalf("GetAppInfo accepted response from non-Cloudflare host; got appInfo=%+v", appInfo)
+	}
+	if !strings.Contains(err.Error(), "non-Cloudflare host") {
+		t.Fatalf("expected non-Cloudflare host error, got: %v", err)
 	}
 }


### PR DESCRIPTION
`token.GetAppInfo` (`token/token.go`) stops the redirect chain when the last request URL contains `AccessLoginWorkerPath` (`/cdn-cgi/access/login`) but does not check that the host serving the response is a Cloudflare-owned host. Once that predicate fires, the response's `CF-Access-Domain` header and the request's `?kid=` query parameter become authoritative for `AppInfo.AppDomain` and `AppInfo.AppAUD`. Both fields flow into `GetAppTokenIfExists` (the on-disk app-token lookup) and `BuildAccessRequest` (which places the per-app Cloudflare Access JWT in the `Cf-Access-Token` header on a request to the host the user invoked `cloudflared` against).

If a victim invokes `cloudflared access curl <attacker-host>` or `cloudflared access login <attacker-host>` against a host whose path namespace includes `/cdn-cgi/access/login`, the existing predicate accepts that response as authoritative. The victim's per-app JWT is then delivered to the attacker server, where it can be replayed against the legitimate Cloudflare Access edge for the JWT's `exp` window.

A realistic delivery vector for the URL substitution that does not require any prior compromise: subdomain takeover of a hostname that appears in team documentation. Setup guides commonly contain literal `cloudflared access curl https://<internal-name>/` snippets, and `<internal-name>` later lapses or is misconfigured into an attacker-controlled CNAME.

## This PR

Adds an `isCloudflareAccessHost` helper that matches `*.cloudflareaccess.com` (case-insensitive, port-tolerant) and gates the `AccessLoginWorkerPath` branch in `GetAppInfo` on the response host satisfying it.

The `CF-Access-Aud` header path on the `else if` branch is a different code shape (the response host is by definition the protected application's host, not a `*.cloudflareaccess.com` host) and is out of scope for this PR; it warrants a separate consideration.

## Tests

- `TestIsCloudflareAccessHost` — unit test over a representative input matrix (positive: subdomains, port-tolerant, case-insensitive; negative: bare `cloudflareaccess.com`, attacker-host, loopback, label-suffix-but-not-subdomain, empty).
- `TestGetAppInfo_RejectsRedirectFromNonCloudflareHost` — `net/http/httptest`-based integration test that drives `GetAppInfo` against a server mimicking the attacker shape (302 to `/cdn-cgi/access/login?kid=AUD`, then 200 with `CF-Access-Domain`) and asserts the new error fires.

Existing tests in `token/` continue to pass.

## Reporting context

For transparency rather than as an appeal: I filed this as **#3709853** on Cloudflare's HackerOne program. The report was closed Not Applicable by H1 triage on threat-model grounds, with reference to preconditions (victim runs command, CI/CD compromised, local access) that don't map cleanly onto the subdomain-takeover vector. I'm opening this PR as a hardening contribution because the bug-shape concern (substring-only predicate with no host check) is decoupled from the threat-model debate, and the fix is small and localized.

Happy to scope down further, drop the unit-test matrix, or close if you'd rather not narrow this particular path.