### PR TITLE
Propagate ICMP echo reply TTL when available

### DIFF
--- a/ingress/icmp_darwin.go
+++ b/ingress/icmp_darwin.go
@@ -210,7 +210,7 @@ func (ip *icmpProxy) Serve(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		reply, err := parseReply(from, buf[:n])
+		reply, err := parseReply(from, buf[:n], receivedTTL{})
 		if err != nil {
 			ip.logger.Debug().Err(err).Str("dst", from.String()).Msg("Failed to parse ICMP reply, continue to parse as full packet")
 			// In unit test, we found out when the listener listens on 0.0.0.0, the socket reads the full packet after
@@ -231,24 +231,36 @@ func (ip *icmpProxy) Serve(ctx context.Context) error {
 	}
 }
 
+func enableReceiveTTL(conn *icmp.PacketConn, listenIP netip.Addr) error {
+	return nil
+}
+
 func (ip *icmpProxy) handleFullPacket(ctx context.Context, decoder *packet.ICMPDecoder, rawPacket []byte) error {
-	icmpPacket, err := decoder.Decode(packet.RawPacket{Data: rawPacket})
+	reply, err := parseFullPacketReply(decoder, rawPacket)
 	if err != nil {
 		return err
 	}
-	echo, err := getICMPEcho(icmpPacket.Message)
-	if err != nil {
-		return err
-	}
-	reply := echoReply{
-		from: icmpPacket.Src,
-		msg:  icmpPacket.Message,
-		echo: echo,
-	}
-	if ip.sendReply(ctx, &reply); err != nil {
+	if err := ip.sendReply(ctx, reply); err != nil {
 		return err
 	}
 	return nil
+}
+
+func parseFullPacketReply(decoder *packet.ICMPDecoder, rawPacket []byte) (*echoReply, error) {
+	icmpPacket, err := decoder.Decode(packet.RawPacket{Data: rawPacket})
+	if err != nil {
+		return nil, err
+	}
+	echo, err := getICMPEcho(icmpPacket.Message)
+	if err != nil {
+		return nil, err
+	}
+	return &echoReply{
+		from: icmpPacket.Src,
+		msg:  icmpPacket.Message,
+		echo: echo,
+		ttl:  receivedTTLFromIPHeader(icmpPacket.TTL),
+	}, nil
 }
 
 func (ip *icmpProxy) sendReply(ctx context.Context, reply *echoReply) error {
@@ -265,9 +277,15 @@ func (ip *icmpProxy) sendReply(ctx context.Context, reply *echoReply) error {
 	_, span := icmpFlow.responder.ReplySpan(ctx, ip.logger)
 	defer icmpFlow.responder.ExportSpan()
 
-	if err := icmpFlow.returnToSrc(reply); err != nil {
+	sent, err := icmpFlow.returnToSrc(reply)
+	if err != nil {
 		tracing.EndWithErrorStatus(span, err)
 		return err
+	}
+	if !sent {
+		ip.logger.Debug().Str("dst", reply.from.String()).Msg("Drop ICMP echo reply because TTL expired")
+		tracing.End(span)
+		return nil
 	}
 	observeICMPReply(ip.logger, span, reply.from.String(), reply.echo.ID, reply.echo.Seq)
 	span.SetAttributes(attribute.Int("originalEchoID", icmpFlow.originalEchoID))

--- a/ingress/icmp_darwin_test.go
+++ b/ingress/icmp_darwin_test.go
@@ -7,10 +7,42 @@ import (
 	"net/netip"
 	"testing"
 
+	"github.com/google/gopacket/layers"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
 
 	"github.com/cloudflare/cloudflared/packet"
 )
+
+func TestParseFullPacketReplyUsesIPTTL(t *testing.T) {
+	t.Parallel()
+
+	pk := &packet.ICMP{
+		IP: &packet.IP{
+			Src:      localhostIP,
+			Dst:      localhostIP,
+			Protocol: layers.IPProtocolICMPv4,
+			TTL:      37,
+		},
+		Message: &icmp.Message{
+			Type: ipv4.ICMPTypeEchoReply,
+			Code: 0,
+			Body: &icmp.Echo{
+				ID:   12345,
+				Seq:  6789,
+				Data: []byte(t.Name()),
+			},
+		},
+	}
+	rawPacket, err := packet.NewEncoder().Encode(pk)
+	require.NoError(t, err)
+
+	reply, err := parseFullPacketReply(packet.NewICMPDecoder(), rawPacket.Data)
+	require.NoError(t, err)
+	require.True(t, reply.ttl.ok)
+	require.Equal(t, uint8(37), reply.ttl.value)
+}
 
 func TestSingleEchoIDTracker(t *testing.T) {
 	tracker := newEchoIDTracker()

--- a/ingress/icmp_linux.go
+++ b/ingress/icmp_linux.go
@@ -20,6 +20,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
 
 	"github.com/cloudflare/cloudflared/packet"
 	"github.com/cloudflare/cloudflared/tracing"
@@ -177,6 +180,55 @@ func (ip *icmpProxy) listenResponse(ctx context.Context, flow *icmpEchoFlow) {
 	}
 }
 
+func enableReceiveTTL(conn *icmp.PacketConn, listenIP netip.Addr) error {
+	if listenIP.Is4() {
+		ipv4Conn := conn.IPv4PacketConn()
+		if ipv4Conn == nil {
+			return nil
+		}
+		if err := ipv4Conn.SetControlMessage(ipv4.FlagTTL, true); err != nil {
+			return fmt.Errorf("failed to enable IPv4 TTL control message: %w", err)
+		}
+		return nil
+	}
+
+	ipv6Conn := conn.IPv6PacketConn()
+	if ipv6Conn == nil {
+		return nil
+	}
+	if err := ipv6Conn.SetControlMessage(ipv6.FlagHopLimit, true); err != nil {
+		return fmt.Errorf("failed to enable IPv6 hop limit control message: %w", err)
+	}
+	return nil
+}
+
+func readICMPReply(conn *icmp.PacketConn, buf []byte) (int, net.Addr, receivedTTL, error) {
+	if ipv4Conn := conn.IPv4PacketConn(); ipv4Conn != nil {
+		n, cm, from, err := ipv4Conn.ReadFrom(buf)
+		if err != nil {
+			return 0, nil, receivedTTL{}, err
+		}
+		if cm == nil {
+			return n, from, receivedTTL{}, nil
+		}
+		return n, from, receivedTTLFromControlMessage(cm.TTL), nil
+	}
+
+	if ipv6Conn := conn.IPv6PacketConn(); ipv6Conn != nil {
+		n, cm, from, err := ipv6Conn.ReadFrom(buf)
+		if err != nil {
+			return 0, nil, receivedTTL{}, err
+		}
+		if cm == nil {
+			return n, from, receivedTTL{}, nil
+		}
+		return n, from, receivedTTLFromControlMessage(cm.HopLimit), nil
+	}
+
+	n, from, err := conn.ReadFrom(buf)
+	return n, from, receivedTTL{}, err
+}
+
 // Listens for ICMP response and handles error logging
 func (ip *icmpProxy) handleResponse(ctx context.Context, flow *icmpEchoFlow, buf []byte) (done bool) {
 	_, span := flow.responder.ReplySpan(ctx, ip.logger)
@@ -186,7 +238,7 @@ func (ip *icmpProxy) handleResponse(ctx context.Context, flow *icmpEchoFlow, buf
 		attribute.Int("originalEchoID", flow.originalEchoID),
 	)
 
-	n, from, err := flow.originConn.ReadFrom(buf)
+	n, from, ttl, err := readICMPReply(flow.originConn, buf)
 	if err != nil {
 		if flow.IsClosed() {
 			tracing.EndWithErrorStatus(span, fmt.Errorf("flow was closed"))
@@ -196,7 +248,7 @@ func (ip *icmpProxy) handleResponse(ctx context.Context, flow *icmpEchoFlow, buf
 		tracing.EndWithErrorStatus(span, err)
 		return true
 	}
-	reply, err := parseReply(from, buf[:n])
+	reply, err := parseReply(from, buf[:n], ttl)
 	if err != nil {
 		ip.logger.Error().Err(err).Str("dst", from.String()).Msg("Failed to parse ICMP reply")
 		tracing.EndWithErrorStatus(span, err)
@@ -209,9 +261,15 @@ func (ip *icmpProxy) handleResponse(ctx context.Context, flow *icmpEchoFlow, buf
 		return false
 	}
 
-	if err := flow.returnToSrc(reply); err != nil {
+	sent, err := flow.returnToSrc(reply)
+	if err != nil {
 		ip.logger.Error().Err(err).Str("dst", from.String()).Msg("Failed to send ICMP reply")
 		tracing.EndWithErrorStatus(span, err)
+		return false
+	}
+	if !sent {
+		ip.logger.Debug().Str("dst", from.String()).Msg("Drop ICMP echo reply because TTL expired")
+		tracing.End(span)
 		return false
 	}
 

--- a/ingress/icmp_posix.go
+++ b/ingress/icmp_posix.go
@@ -19,10 +19,27 @@ import (
 
 // Opens a non-privileged ICMP socket on Linux and Darwin
 func newICMPConn(listenIP netip.Addr) (*icmp.PacketConn, error) {
+	var (
+		network string
+		err     error
+	)
 	if listenIP.Is4() {
-		return icmp.ListenPacket("udp4", listenIP.String())
+		network = "udp4"
+	} else {
+		network = "udp6"
 	}
-	return icmp.ListenPacket("udp6", listenIP.String())
+
+	conn, err := icmp.ListenPacket(network, listenIP.String())
+	if err != nil {
+		return nil, err
+	}
+	if err := enableReceiveTTL(conn, listenIP); err != nil {
+		if closeErr := conn.Close(); closeErr != nil {
+			return nil, fmt.Errorf("%w; failed to close ICMP socket after error: %v", err, closeErr)
+		}
+		return nil, err
+	}
+	return conn, nil
 }
 
 func netipAddr(addr net.Addr) (netip.Addr, bool) {
@@ -120,8 +137,12 @@ func (ief *icmpEchoFlow) sendToDst(dst netip.Addr, msg *icmp.Message) error {
 }
 
 // returnToSrc rewrites the echo ID to the original echo ID from the eyeball
-func (ief *icmpEchoFlow) returnToSrc(reply *echoReply) error {
+func (ief *icmpEchoFlow) returnToSrc(reply *echoReply) (bool, error) {
 	ief.UpdateLastActive()
+	ttl, shouldForward := reply.ttl.forwardedTTL()
+	if !shouldForward {
+		return false, nil
+	}
 	reply.echo.ID = ief.originalEchoID
 	reply.msg.Body = reply.echo
 	pk := packet.ICMP{
@@ -129,20 +150,21 @@ func (ief *icmpEchoFlow) returnToSrc(reply *echoReply) error {
 			Src:      reply.from,
 			Dst:      ief.src,
 			Protocol: layers.IPProtocol(reply.msg.Type.Protocol()),
-			TTL:      packet.DefaultTTL,
+			TTL:      ttl,
 		},
 		Message: reply.msg,
 	}
-	return ief.responder.ReturnPacket(&pk)
+	return true, ief.responder.ReturnPacket(&pk)
 }
 
 type echoReply struct {
 	from netip.Addr
 	msg  *icmp.Message
 	echo *icmp.Echo
+	ttl  receivedTTL
 }
 
-func parseReply(from net.Addr, rawMsg []byte) (*echoReply, error) {
+func parseReply(from net.Addr, rawMsg []byte, ttl receivedTTL) (*echoReply, error) {
 	fromAddr, ok := netipAddr(from)
 	if !ok {
 		return nil, fmt.Errorf("cannot convert %s to netip.Addr", from)
@@ -163,6 +185,7 @@ func parseReply(from net.Addr, rawMsg []byte) (*echoReply, error) {
 		from: fromAddr,
 		msg:  msg,
 		echo: echo,
+		ttl:  ttl,
 	}, nil
 }
 

--- a/ingress/icmp_posix_test.go
+++ b/ingress/icmp_posix_test.go
@@ -18,6 +18,75 @@ import (
 	"github.com/cloudflare/cloudflared/packet"
 )
 
+func TestReturnToSrcUsesReplyTTL(t *testing.T) {
+	t.Parallel()
+
+	const originalEchoID = 42573
+	muxer := newMockMuxer(1)
+	responder := newPacketResponder(muxer, 0, packet.NewEncoder())
+	flow := newICMPEchoFlow(localhostIP, func() error { return nil }, nil, responder, 0, originalEchoID)
+
+	sent, err := flow.returnToSrc(&echoReply{
+		from: localhostIP,
+		msg: &icmp.Message{
+			Type: ipv4.ICMPTypeEchoReply,
+			Code: 0,
+		},
+		echo: &icmp.Echo{
+			ID:   12345,
+			Seq:  6789,
+			Data: []byte(t.Name()),
+		},
+		ttl: receivedTTLFromIPHeader(42),
+	})
+	require.NoError(t, err)
+	require.True(t, sent)
+
+	resp := <-muxer.cfdToEdge
+	decoder := packet.NewICMPDecoder()
+	decoded, err := decoder.Decode(packet.RawPacket{Data: resp.Payload()})
+	require.NoError(t, err)
+	require.Equal(t, uint8(41), decoded.TTL)
+	require.Equal(t, localhostIP, decoded.Src)
+	require.Equal(t, localhostIP, decoded.Dst)
+	require.Equal(t, ipv4.ICMPTypeEchoReply, decoded.Type)
+	require.Equal(t, &icmp.Echo{
+		ID:   originalEchoID,
+		Seq:  6789,
+		Data: []byte(t.Name()),
+	}, decoded.Body)
+}
+
+func TestReturnToSrcDropsExpiredReplyTTL(t *testing.T) {
+	t.Parallel()
+
+	muxer := newMockMuxer(1)
+	responder := newPacketResponder(muxer, 0, packet.NewEncoder())
+	flow := newICMPEchoFlow(localhostIP, func() error { return nil }, nil, responder, 0, 42573)
+
+	sent, err := flow.returnToSrc(&echoReply{
+		from: localhostIP,
+		msg: &icmp.Message{
+			Type: ipv4.ICMPTypeEchoReply,
+			Code: 0,
+		},
+		echo: &icmp.Echo{
+			ID:   12345,
+			Seq:  6789,
+			Data: []byte(t.Name()),
+		},
+		ttl: receivedTTLFromIPHeader(1),
+	})
+	require.NoError(t, err)
+	require.False(t, sent)
+
+	select {
+	case pk := <-muxer.cfdToEdge:
+		t.Fatalf("received unexpected ICMP reply: %+v", pk)
+	default:
+	}
+}
+
 func TestFunnelIdleTimeout(t *testing.T) {
 	defer leaktest.Check(t)()
 

--- a/ingress/icmp_windows.go
+++ b/ingress/icmp_windows.go
@@ -285,11 +285,16 @@ func (ip *icmpProxy) Request(ctx context.Context, pk *packet.ICMP, responder ICM
 	responder.ExportSpan()
 
 	_, replySpan := responder.ReplySpan(ctx, ip.logger)
-	err = ip.handleEchoReply(pk, echo, resp, responder)
+	sent, err := ip.handleEchoReply(pk, echo, resp, responder)
 	if err != nil {
 		ip.logger.Err(err).Msg("Failed to send ICMP reply")
 		tracing.EndWithErrorStatus(replySpan, err)
 		return errors.Wrap(err, "failed to handle ICMP echo reply")
+	}
+	if !sent {
+		ip.logger.Debug().Str("dst", pk.Dst.String()).Msg("Drop ICMP echo reply because TTL expired")
+		tracing.End(replySpan)
+		return nil
 	}
 	observeICMPReply(ip.logger, replySpan, pk.Dst.String(), echo.ID, echo.Seq)
 	replySpan.SetAttributes(
@@ -300,7 +305,7 @@ func (ip *icmpProxy) Request(ctx context.Context, pk *packet.ICMP, responder ICM
 	return nil
 }
 
-func (ip *icmpProxy) handleEchoReply(request *packet.ICMP, echoReq *icmp.Echo, resp echoResp, responder ICMPResponder) error {
+func (ip *icmpProxy) handleEchoReply(request *packet.ICMP, echoReq *icmp.Echo, resp echoResp, responder ICMPResponder) (bool, error) {
 	var replyType icmp.Type
 	if request.Dst.Is4() {
 		replyType = ipv4.ICMPTypeEchoReply
@@ -308,12 +313,21 @@ func (ip *icmpProxy) handleEchoReply(request *packet.ICMP, echoReq *icmp.Echo, r
 		replyType = ipv6.ICMPTypeEchoReply
 	}
 
+	ttl := packet.DefaultTTL
+	if received, ok := resp.ttl(); ok {
+		forwarded, shouldForward := receivedTTLFromIPHeader(received).forwardedTTL()
+		if !shouldForward {
+			return false, nil
+		}
+		ttl = forwarded
+	}
+
 	pk := packet.ICMP{
 		IP: &packet.IP{
 			Src:      request.Dst,
 			Dst:      request.Src,
 			Protocol: layers.IPProtocol(request.Type.Protocol()),
-			TTL:      packet.DefaultTTL,
+			TTL:      ttl,
 		},
 		Message: &icmp.Message{
 			Type: replyType,
@@ -325,7 +339,7 @@ func (ip *icmpProxy) handleEchoReply(request *packet.ICMP, echoReq *icmp.Echo, r
 			},
 		},
 	}
-	return responder.ReturnPacket(&pk)
+	return true, responder.ReturnPacket(&pk)
 }
 
 func (ip *icmpProxy) icmpEchoRoundtrip(dst netip.Addr, echo *icmp.Echo) (echoResp, error) {
@@ -410,6 +424,7 @@ type echoResp interface {
 	status() ipStatus
 	rtt() uint32
 	payload() []byte
+	ttl() (uint8, bool)
 }
 
 type echoV4Resp struct {
@@ -427,6 +442,10 @@ func (r *echoV4Resp) rtt() uint32 {
 
 func (r *echoV4Resp) payload() []byte {
 	return r.data
+}
+
+func (r *echoV4Resp) ttl() (uint8, bool) {
+	return r.reply.Options.TTL, true
 }
 
 func newEchoV4Resp(replyBuf []byte) (*echoV4Resp, error) {
@@ -525,6 +544,10 @@ func (r *echoV6Resp) rtt() uint32 {
 
 func (r *echoV6Resp) payload() []byte {
 	return r.data
+}
+
+func (r *echoV6Resp) ttl() (uint8, bool) {
+	return 0, false
 }
 
 func newEchoV6Resp(replyBuf []byte, dataSize int) (*echoV6Resp, error) {

--- a/ingress/icmp_windows_test.go
+++ b/ingress/icmp_windows_test.go
@@ -12,8 +12,11 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/google/gopacket/layers"
 	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
 
+	"github.com/cloudflare/cloudflared/packet"
 	"github.com/stretchr/testify/require"
 )
 
@@ -123,6 +126,51 @@ func TestParseEchoV6Reply(t *testing.T) {
 			require.True(t, bytes.Equal(resp.data, test.expectedData))
 		}
 	}
+}
+
+func TestHandleEchoReplyUsesIPv4TTL(t *testing.T) {
+	t.Parallel()
+
+	echo := &icmp.Echo{
+		ID:   6193,
+		Seq:  25712,
+		Data: []byte(t.Name()),
+	}
+	request := &packet.ICMP{
+		IP: &packet.IP{
+			Src:      localhostIP,
+			Dst:      netip.MustParseAddr("192.0.2.200"),
+			Protocol: layers.IPProtocolICMPv4,
+		},
+		Message: &icmp.Message{
+			Type: ipv4.ICMPTypeEcho,
+			Code: 0,
+			Body: echo,
+		},
+	}
+	resp := &echoV4Resp{
+		reply: &echoReply{
+			Status: success,
+			Options: ipOption{
+				TTL: 59,
+			},
+		},
+		data: []byte(t.Name()),
+	}
+	muxer := newMockMuxer(1)
+	responder := newPacketResponder(muxer, 0, packet.NewEncoder())
+
+	sent, err := (&icmpProxy{}).handleEchoReply(request, echo, resp, responder)
+	require.NoError(t, err)
+	require.True(t, sent)
+
+	pk := <-muxer.cfdToEdge
+	decoded, err := packet.NewICMPDecoder().Decode(packet.RawPacket{Data: pk.Payload()})
+	require.NoError(t, err)
+	require.Equal(t, uint8(58), decoded.TTL)
+	require.Equal(t, request.Dst, decoded.Src)
+	require.Equal(t, request.Src, decoded.Dst)
+	require.Equal(t, ipv4.ICMPTypeEchoReply, decoded.Type)
 }
 
 // TestSendEchoErrors makes sure icmpSendEcho handles error cases

--- a/ingress/origin_icmp_proxy.go
+++ b/ingress/origin_icmp_proxy.go
@@ -3,6 +3,7 @@ package ingress
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/netip"
 	"time"
 
@@ -26,6 +27,38 @@ const (
 var (
 	errPacketNil = fmt.Errorf("packet is nil")
 )
+
+type receivedTTL struct {
+	value uint8
+	ok    bool
+}
+
+func receivedTTLFromControlMessage(value int) receivedTTL {
+	if value <= 0 || value > math.MaxUint8 {
+		return receivedTTL{}
+	}
+	return receivedTTL{
+		value: uint8(value),
+		ok:    true,
+	}
+}
+
+func receivedTTLFromIPHeader(value uint8) receivedTTL {
+	return receivedTTL{
+		value: value,
+		ok:    true,
+	}
+}
+
+func (ttl receivedTTL) forwardedTTL() (uint8, bool) {
+	if !ttl.ok {
+		return packet.DefaultTTL, true
+	}
+	if ttl.value <= 1 {
+		return 0, false
+	}
+	return ttl.value - 1, true
+}
 
 // ICMPRouterServer is a parent interface over-top of ICMPRouter that allows for the operation of the proxy origin listeners.
 type ICMPRouterServer interface {


### PR DESCRIPTION
Adds TTL/HopLimit propagation for ICMP Echo Reply packets returned from the origin.

cloudflared already behaves like one hop on the request path by decrementing the TTL/HopLimit before forwarding ICMP packets to the origin. This change applies the same behavior on the reply path when the origin reply TTL/HopLimit is available: cloudflared decrements it by 1 before returning the packet to the eyeball.

Replies whose received TTL/HopLimit is 1 or lower are dropped instead of returning a packet with TTL=0. When the reply TTL/HopLimit is unavailable, cloudflared keeps the existing default TTL fallback.

Fixes #1657

## Supported paths

Linux now reads IPv4 TTL and IPv6 HopLimit from packet control messages, so both IPv4 and IPv6 Echo Replies can preserve the origin reply hop limit.

Windows IPv4 uses the TTL from the parsed `IcmpSendEcho` reply.

## Partial and fallback behavior

Darwin keeps the existing default TTL fallback on the normal socket read path, where the reply is parsed as an ICMP message without IP header metadata. When Darwin returns a full IP packet and cloudflared can decode the IP header, the reply TTL from that header is preserved and decremented.

Windows IPv6 keeps the existing default TTL behavior because the current parsed `Icmp6SendEcho2` reply path does not expose HopLimit.

Any other path where cloudflared cannot obtain the received TTL/HopLimit also keeps the default TTL fallback.