### PR TITLE
Fix version typo in RELEASE_NOTES

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,5 @@
 2026.6.0
-- 2026-06-08 TUN-10558: Bump go to v1.24.4, x/crypto to v0.52.0 and google.golang.org/grpc to v1.81.1
+- 2026-06-08 TUN-10558: Bump go to v1.26.4, x/crypto to v0.52.0 and google.golang.org/grpc to v1.81.1
 - 2026-06-01 TUN-10563: introduce QUICConnection interface
 
 2026.5.2


### PR DESCRIPTION
(does not match commit message, but does match actual change)