### PR TITLE
fix: close leaked file handles in config and token key loading

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -411,6 +411,7 @@ func ReadConfigFile(c *cli.Context, log *zerolog.Logger) (settings *configFileSe
 
 	// Parse it again, with strict mode, to find warnings.
 	if file, err := os.Open(configFile); err == nil {
+		defer func() { _ = file.Close() }()
 		decoder := yaml.NewDecoder(file)
 		decoder.KnownFields(true)
 		var unusedConfig configFileSettings

--- a/token/encrypt.go
+++ b/token/encrypt.go
@@ -151,6 +151,7 @@ func (e *Encrypter) fetchKey(filename string) (*[32]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = f.Close() }()
 	buf := new(bytes.Buffer)
 	io.Copy(buf, f)
 


### PR DESCRIPTION
Hi,

I've built a static analyzer for Go called [Ghoul](https://fereidani.com/ghoul), and I ran it against the cloudflared codebase. It flagged a couple of file handles that are opened but never closed, which can leak file descriptors over the lifetime of the process (and across config reloads). This PR closes both.

Ghoul related reports:
```txt
config/configuration.go:422:2: [resource-leak] resource from os.Open allocated at config/configuration.go:413 never closed (confidence: 6.4/10, CWE-404)
  --> config/configuration.go:413:25: source:      resource allocated by os.Open
token/encrypt.go:159:3: [resource-leak] resource from os.Open allocated at token/encrypt.go:150 never closed (confidence: 6.4/10, CWE-404)
  --> token/encrypt.go:150:19: source:      resource allocated by os.Open
token/encrypt.go:164:2: [resource-leak] resource from os.Open allocated at token/encrypt.go:150 never closed (confidence: 6.4/10, CWE-404)
  --> token/encrypt.go:150:19: source:      resource allocated by os.Open
```

Changes:
- `config/configuration.go`: the strict-mode re-parse in `ReadConfigFile` opens the config file a second time without closing it. Added a deferred close so the handle is released on every path.
- `token/encrypt.go`: `Encrypter.fetchKey` opens the key file but never closes it on any return path. Added a deferred close.

Both use the project's `defer func() { _ = file.Close() }()` convention.