### PR TITLE
修复多处资源泄漏、错误处理缺陷与并发数据竞争

### DIFF
--- a/cmd/cloudflared/linux_service.go
+++ b/cmd/cloudflared/linux_service.go
@@ -524,7 +524,7 @@ func ensureConfigDirExists(configDir string) error {
 	return err
 }
 
-func copyFile(src, dest string) error {
+func copyFile(src, dest string) (err error) {
 	srcFile, err := os.Open(src) //nolint:gosec // operator-provided service config path
 	if err != nil {
 		return err
@@ -537,13 +537,19 @@ func copyFile(src, dest string) error {
 	}
 	ok := false
 	defer func() {
-		_ = destFile.Close()
+		// 关闭错误可能反映延迟刷盘失败; 失败时删除不完整的目标文件并返回错误, 避免保留损坏的 service 配置
+		if closeErr := destFile.Close(); closeErr != nil {
+			if err == nil {
+				err = closeErr
+			}
+			ok = false
+		}
 		if !ok {
 			_ = os.Remove(dest)
 		}
 	}()
 
-	if _, err := io.Copy(destFile, srcFile); err != nil {
+	if _, err = io.Copy(destFile, srcFile); err != nil {
 		return err
 	}
 

--- a/cmd/cloudflared/tail/cmd.go
+++ b/cmd/cloudflared/tail/cmd.go
@@ -301,9 +301,13 @@ func Run(c *cli.Context) error {
 		HTTPHeader: header,
 	})
 	if err != nil {
-		if resp != nil && resp.StatusCode != http.StatusSwitchingProtocols {
-			handleValidationError(resp, log)
-			return nil
+		if resp != nil {
+			// nhooyr.io/websocket 要求 Dial 返回错误时由调用方负责关闭 resp.Body, 否则连接泄漏
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusSwitchingProtocols {
+				handleValidationError(resp, log)
+				return nil
+			}
 		}
 		log.Error().Err(err).Msgf("unable to start management log streaming session")
 		return nil

--- a/cmd/cloudflared/updater/check.go
+++ b/cmd/cloudflared/updater/check.go
@@ -11,7 +11,9 @@ type VersionWarningChecker struct {
 
 func StartWarningCheck(c *cli.Context) VersionWarningChecker {
 	checker := VersionWarningChecker{
-		warningChan: make(chan string),
+		// 带缓冲的 channel: getWarning 使用 select/default 非阻塞读取, 若在网络请求完成前被读取,
+		// 无缓冲 channel 会导致发送方 goroutine 永久阻塞, 造成泄漏. 缓冲为 1 保证发送方总能完成发送并 close.
+		warningChan: make(chan string, 1),
 	}
 
 	go func() {

--- a/cmd/cloudflared/updater/update.go
+++ b/cmd/cloudflared/updater/update.go
@@ -240,6 +240,7 @@ func createUpdateConfig(updateDisabled bool, freq time.Duration, log *zerolog.Lo
 // download immediately and restart after starting (in the case that there is an upgrade available).
 func (a *AutoUpdater) Run(ctx context.Context) error {
 	ticker := time.NewTicker(a.configurable.freq)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():

--- a/cmd/cloudflared/updater/workers_update.go
+++ b/cmd/cloudflared/updater/workers_update.go
@@ -190,10 +190,14 @@ func download(url, filepath string, isCompressed bool) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
 
-	_, err = io.Copy(out, r)
-	return err
+	// 显式关闭以捕获刷盘错误; 否则 io.Copy 成功但 Close 失败时会使用不完整的二进制执行更新
+	_, copyErr := io.Copy(out, r)
+	closeErr := out.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
 }
 
 // isCompressedFile is a really simple file extension check to see if this is a macos tar and gzipped
@@ -218,7 +222,6 @@ func writeBatchFile(targetPath string, newPath string, oldPath string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 	cfdName := filepath.Base(targetPath)
 	oldName := filepath.Base(oldPath)
 
@@ -233,9 +236,16 @@ func writeBatchFile(targetPath string, newPath string, oldPath string) error {
 
 	t, err := template.New("batch").Parse(windowsUpdateCommandTemplate)
 	if err != nil {
+		_ = f.Close()
 		return err
 	}
-	return t.Execute(f, data)
+	// 显式关闭以捕获刷盘错误, 避免生成不完整的批处理文件却报告成功
+	execErr := t.Execute(f, data)
+	closeErr := f.Close()
+	if execErr != nil {
+		return execErr
+	}
+	return closeErr
 }
 
 // run each OS command for windows

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -411,6 +411,7 @@ func ReadConfigFile(c *cli.Context, log *zerolog.Logger) (settings *configFileSe
 
 	// Parse it again, with strict mode, to find warnings.
 	if file, err := os.Open(configFile); err == nil {
+		defer func() { _ = file.Close() }()
 		decoder := yaml.NewDecoder(file)
 		decoder.KnownFields(true)
 		var unusedConfig configFileSettings

--- a/datagramsession/session.go
+++ b/datagramsession/session.go
@@ -120,7 +120,10 @@ func (s *Session) dstToTransport(buffer []byte) (closeSession bool, err error) {
 			Payload: buffer[:n],
 		}
 		if sendErr := s.sendFunc(&session); sendErr != nil {
-			return false, sendErr
+			// 发送到 edge transport 失败意味着链路已不可用, session 无法继续转发数据.
+			// 返回 closeSession=true 关闭会话, 避免在 origin 持续上报数据时陷入只读只失败的快速循环
+			// (与 quic/v3 session.readLoop 中发送失败即关闭的行为保持一致).
+			return true, sendErr
 		}
 	}
 	return err != nil, err

--- a/features/selector.go
+++ b/features/selector.go
@@ -156,6 +156,7 @@ func (fs *featureSelector) refresh(ctx context.Context) error {
 
 func (fs *featureSelector) refreshLoop(ctx context.Context, refreshFreq time.Duration) {
 	ticker := time.NewTicker(refreshFreq)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():

--- a/hello/hello.go
+++ b/hello/hello.go
@@ -206,6 +206,7 @@ func sseHandler(log *zerolog.Logger) http.HandlerFunc {
 		}
 		log.Info().Msgf("Server Sent Events every %s", freq)
 		ticker := time.NewTicker(freq)
+		defer ticker.Stop()
 		counter := 0
 		for {
 			select {

--- a/quic/v3/session.go
+++ b/quic/v3/session.go
@@ -85,7 +85,9 @@ type session struct {
 	closeWrite  chan struct{}
 	contextChan chan context.Context
 	metrics     Metrics
-	log         *zerolog.Logger
+	// log 通过 atomic.Pointer 保护: Migrate 在独立 goroutine 中重写 log, 而 readLoop/writeLoop/Write
+	// 并发读取, 直接使用 *zerolog.Logger 字段会产生数据竞争 (go test -race 会报 DATA RACE).
+	log atomic.Pointer[zerolog.Logger]
 
 	// A special close function that we wrap with sync.Once to make sure it is only called once
 	closeFn func() error
@@ -124,7 +126,6 @@ func NewSession(
 		// contextChan is an unbounded channel to help enforce one active migration of a session at a time.
 		contextChan: make(chan context.Context),
 		metrics:     metrics,
-		log:         &logger,
 		closeFn: sync.OnceValue(func() error {
 			// We don't want to block on sending to the close channel if it is already full
 			select {
@@ -138,6 +139,7 @@ func NewSession(
 		}),
 	}
 	session.eyeball.Store(&eyeball)
+	session.log.Store(&logger)
 	return session
 }
 
@@ -165,7 +167,7 @@ func (s *session) Migrate(eyeball DatagramConn, ctx context.Context, logger *zer
 		s.eyeball.Store(&eyeball)
 		s.contextChan <- ctx
 		log := logger.With().Str(logFlowID, s.id.String()).Logger()
-		s.log = &log
+		s.log.Store(&log)
 	}
 	// The session is already running so we want to restart the idle timeout since no proxied packets have come down yet.
 	s.markActive()
@@ -193,19 +195,19 @@ func (s *session) readLoop() {
 		n, err := s.origin.Read(readBuffer[DatagramPayloadHeaderLen:])
 		if err != nil {
 			if isConnectionClosed(err) {
-				s.log.Debug().Msgf("flow (read) connection closed: %v", err)
+				s.log.Load().Debug().Msgf("flow (read) connection closed: %v", err)
 			}
 			s.closeSession(err)
 			return
 		}
 		if n < 0 {
 			s.metrics.DroppedUDPDatagram(s.ConnectionID(), DroppedReadFailed)
-			s.log.Warn().Int(logPacketSizeKey, n).Msg("flow (origin) packet read was negative and was dropped")
+			s.log.Load().Warn().Int(logPacketSizeKey, n).Msg("flow (origin) packet read was negative and was dropped")
 			continue
 		}
 		if n > maxDatagramPayloadLen {
 			s.metrics.DroppedUDPDatagram(s.ConnectionID(), DroppedReadTooLarge)
-			s.log.Error().Int(logPacketSizeKey, n).Msg("flow (origin) packet read was too large and was dropped")
+			s.log.Load().Error().Int(logPacketSizeKey, n).Msg("flow (origin) packet read was too large and was dropped")
 			continue
 		}
 		// We need to synchronize on the eyeball in-case that the connection was migrated. This should be rarely a point
@@ -228,7 +230,7 @@ func (s *session) Write(payload []byte) {
 	case s.writeChan <- payload:
 	default:
 		s.metrics.DroppedUDPDatagram(s.ConnectionID(), DroppedWriteFull)
-		s.log.Error().Msg("failed to write flow payload to origin: dropped")
+		s.log.Load().Error().Msg("failed to write flow payload to origin: dropped")
 	}
 }
 
@@ -246,13 +248,13 @@ func (s *session) writeLoop() {
 				// Check if this is a write deadline exceeded to the connection
 				if errors.Is(err, os.ErrDeadlineExceeded) {
 					s.metrics.DroppedUDPDatagram(s.ConnectionID(), DroppedWriteDeadlineExceeded)
-					s.log.Warn().Err(err).Msg("flow (write) deadline exceeded: dropping packet")
+					s.log.Load().Warn().Err(err).Msg("flow (write) deadline exceeded: dropping packet")
 					continue
 				}
 				if isConnectionClosed(err) {
-					s.log.Debug().Msgf("flow (write) connection closed: %v", err)
+					s.log.Load().Debug().Msgf("flow (write) connection closed: %v", err)
 				}
-				s.log.Err(err).Msg("failed to write flow payload to origin")
+				s.log.Load().Err(err).Msg("failed to write flow payload to origin")
 				s.closeSession(err)
 				// If we fail to write to the origin socket, we need to end the writer and close the session
 				return
@@ -260,7 +262,7 @@ func (s *session) writeLoop() {
 			// Write must return a non-nil error if it returns n < len(p). https://pkg.go.dev/io#Writer
 			if n < len(payload) {
 				s.metrics.DroppedUDPDatagram(s.ConnectionID(), DroppedWriteFailed)
-				s.log.Err(io.ErrShortWrite).Msg("failed to write the full flow payload to origin")
+				s.log.Load().Err(io.ErrShortWrite).Msg("failed to write the full flow payload to origin")
 				continue
 			}
 			// Mark the session as active since we successfully proxied a packet to the origin.
@@ -281,7 +283,7 @@ func (s *session) closeSession(err error) {
 	default:
 		// In the case that the errChan is already full, we will skip over it and return as to not block
 		// the caller because we should start cleaning up the session.
-		s.log.Warn().Msg("error channel was full")
+		s.log.Load().Warn().Msg("error channel was full")
 	}
 }
 

--- a/token/encrypt.go
+++ b/token/encrypt.go
@@ -137,12 +137,13 @@ func (e *Encrypter) writeKey(key []byte, pemType, filename string) error {
 		return err
 	}
 
-	_, err = f.Write(data)
-	if err != nil {
-		return err
+	// 写入后必须关闭文件; 关闭错误可能反映延迟刷盘失败, 需要返回给调用方
+	_, writeErr := f.Write(data)
+	closeErr := f.Close()
+	if writeErr != nil {
+		return writeErr
 	}
-
-	return nil
+	return closeErr
 }
 
 // fetchKey will load a a DER formatted key from disk
@@ -151,8 +152,11 @@ func (e *Encrypter) fetchKey(filename string) (*[32]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = f.Close() }()
 	buf := new(bytes.Buffer)
-	io.Copy(buf, f)
+	if _, err := io.Copy(buf, f); err != nil {
+		return nil, err
+	}
 
 	p, _ := pem.Decode(buf.Bytes())
 	if p == nil {

--- a/tunnelrpc/pogs/session_manager.go
+++ b/tunnelrpc/pogs/session_manager.go
@@ -164,7 +164,9 @@ func (c SessionManager_PogsClient) RegisterUdpSession(ctx context.Context, sessi
 		}
 		p.SetDstPort(dstPort)
 		p.SetCloseAfterIdleHint(int64(closeAfterIdleHint))
-		_ = p.SetTraceContext(traceContext)
+		if err := p.SetTraceContext(traceContext); err != nil {
+			return err
+		}
 		return nil
 	})
 	result, err := promise.Result().Struct()


### PR DESCRIPTION
## 背景

对 cloudflared 代码库进行系统性代码审查后, 发现多处资源泄漏、错误处理缺陷与并发数据竞争问题。本 PR 修复其中 12 处确信的真实缺陷, 均为最小化外科手术式修改, 未改变任何公共 API。

## 修改内容

### 资源泄漏

| 文件 | 问题 | 修复 |
|------|------|------|
| `token/encrypt.go` | `writeKey`/`fetchKey` 未关闭文件句柄; `fetchKey` 还忽略了 `io.Copy` 错误 | 显式关闭并返回关闭错误; 检查 `io.Copy` 错误 |
| `config/configuration.go` | strict 模式二次打开配置文件未关闭, 每次(重)加载泄漏一个 fd | 增加 `defer file.Close()` |
| `cmd/cloudflared/updater/update.go` | `AutoUpdater.Run` 的 `time.NewTicker` 未 `Stop` | 增加 `defer ticker.Stop()` |
| `features/selector.go` | `refreshLoop` 的 ticker 未 `Stop` | 增加 `defer ticker.Stop()` |
| `hello/hello.go` | `sseHandler` 的 ticker 未 `Stop` | 增加 `defer ticker.Stop()` |
| `cmd/cloudflared/updater/check.go` | `StartWarningCheck` 使用无缓冲 channel, `getWarning` 用 `select/default` 非阻塞读取, 若在网络请求完成前被读取, 发送方 goroutine 永久阻塞泄漏 | 改为 `make(chan string, 1)` |
| `cmd/cloudflared/tail/cmd.go` | `websocket.Dial` 返回错误时未关闭 `resp.Body` (nhooyr.io/websocket 要求调用方关闭) | 在错误路径 `defer resp.Body.Close()` |

### 错误处理

| 文件 | 问题 | 修复 |
|------|------|------|
| `tunnelrpc/pogs/session_manager.go` | `RegisterUdpSession` 中 `SetTraceContext` 错误被 `_ =` 吞掉, 与同函数其他字段处理不一致 | 检查并返回错误 |
| `cmd/cloudflared/updater/workers_update.go` | `download` 与 `writeBatchFile` 忽略 `Close` 错误, 可能用不完整的二进制/批处理文件执行更新 | 显式关闭并返回关闭错误 |
| `cmd/cloudflared/linux_service.go` | `copyFile` 忽略 `Close` 错误, 刷盘失败时仍保留不完整的 service 配置 (`ok=true` 先于 Close 设置) | Close 失败时删除目标文件并返回错误 |

### 并发安全

| 文件 | 问题 | 修复 |
|------|------|------|
| `quic/v3/session.go` | `session.log` (`*zerolog.Logger`) 在 `Migrate` 中无锁写入, 而 `readLoop`/`writeLoop`/`Write` 并发读取, 构成数据竞争 (`go test -race` 会报 `DATA RACE`)。`s.eyeball` 已用 `atomic.Pointer` 保护, 唯独 `s.log` 遗漏 | 改为 `atomic.Pointer[zerolog.Logger]`, 用 `Store`/`Load` 访问 |

### 逻辑修复

| 文件 | 问题 | 修复 |
|------|------|------|
| `datagramsession/session.go` | `dstToTransport` 中 `sendFunc` 失败时返回 `closeSession=false`, 导致会话不关闭; 当 origin 持续上报数据时会陷入"读取-发送失败-日志-重复"的快速循环, 耗费 CPU 并刷爆日志 | 改为 `return true, sendErr` 关闭会话, 与 `quic/v3` session.readLoop 中发送失败即关闭的行为一致 |

## 验证

- 所有改动为最小化外科手术式修改, 未改变公共 API。
- 由于本地环境未安装 Go 工具链, 未能运行 `make test lint`; 改动均已人工逐行核对语法与并发语义, 恳请 CI 校验。

## 备注

审查中还发现 `ingress/icmp_linux.go` 存在一处 ICMP flow 的 goroutine+socket 泄漏 (`listenResponse` 永久阻塞在 `ReadFrom`, ctx 取消时不关闭 funnel)。因修复需在共享的 `packet.FunnelTracker` 上新增方法并处理双重关闭语义, 为控制本 PR 风险与范围暂未包含, 建议作为后续独立 PR 处理。
