### PR TITLE
Add RandomizedDelaySec to cloudflared-update.timer

### DIFF
--- a/cmd/cloudflared/linux_service.go
+++ b/cmd/cloudflared/linux_service.go
@@ -107,6 +107,8 @@ Description=Update cloudflared
 
 [Timer]
 OnCalendar=daily
+RandomizedDelaySec=12h
+Persistent=true
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
## Summary
- Adds `RandomizedDelaySec=12h` and `Persistent=true` to the generated `cloudflared-update.timer` systemd unit.
- Without this, `OnCalendar=daily` fires every replica at exactly `00:00:00`, so fleets running multiple `cloudflared` instances for HA failover all pull the update and restart at the same instant, causing a brief total outage instead of a staggered rollout.

## Test plan
- [x] `go build ./cmd/cloudflared/...`
- [x] `go test -race ./cmd/cloudflared/...`
- [x] `gofmt -l` / `go vet ./cmd/cloudflared/...`
- [x] `make lint` (golangci-lint in this sandbox is built against an older Go toolchain than this repo's `go 1.26` and refuses to run; CI should cover this)

Fixes #1645