### PR TITLE
config: reject overflowing seconds in CustomDuration.UnmarshalJSON

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -435,10 +436,20 @@ func (s CustomDuration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.Duration.Seconds())
 }
 
+// Bounds on the number of seconds that can be converted to a time.Duration (nanoseconds)
+// without overflowing int64.
+const (
+	maxDurationSeconds = int64(math.MaxInt64) / int64(time.Second)
+	minDurationSeconds = int64(math.MinInt64) / int64(time.Second)
+)
+
 func (s *CustomDuration) UnmarshalJSON(data []byte) error {
 	seconds, err := strconv.ParseInt(string(data), 10, 64)
 	if err != nil {
 		return err
+	}
+	if seconds > maxDurationSeconds || seconds < minDurationSeconds {
+		return fmt.Errorf("%d seconds overflows time.Duration, must be between %d and %d seconds", seconds, minDurationSeconds, maxDurationSeconds)
 	}
 
 	s.Duration = time.Duration(seconds * int64(time.Second))

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -36,7 +36,7 @@ var (
 	defaultUserConfigDirs = []string{"~/.cloudflared", "~/.cloudflare-warp", "~/cloudflare-warp"}
 	defaultNixConfigDirs  = []string{"/etc/cloudflared", DefaultUnixConfigLocation}
 
-	ErrNoConfigFile = fmt.Errorf("Cannot determine default configuration path. No file %v in %v", DefaultConfigFiles, DefaultConfigSearchDirectories())
+	ErrNoConfigFile = fmt.Errorf("cannot determine default configuration path. No file %v in %v", DefaultConfigFiles, DefaultConfigSearchDirectories())
 )
 
 const (
@@ -50,7 +50,8 @@ func DefaultConfigDirectory() string {
 		path := os.Getenv("CFDPATH")
 		if path == "" {
 			path = filepath.Join(os.Getenv("ProgramFiles(x86)"), "cloudflared")
-			if _, err := os.Stat(path); os.IsNotExist(err) { // doesn't exist, so return an empty failure string
+			// doesn't exist, so return an empty failure string
+			if _, err := os.Stat(path); os.IsNotExist(err) { //nolint:gosec // path is derived from a fixed local install location, not attacker-controlled input
 				return ""
 			}
 		}
@@ -88,7 +89,7 @@ func DefaultConfigSearchDirectories() []string {
 
 // FileExists checks to see if a file exist at the provided path.
 func FileExists(path string) (bool, error) {
-	f, err := os.Open(path)
+	f, err := os.Open(path) //nolint:gosec // path is one of the local default config search paths, not attacker-controlled input
 	if err != nil {
 		if os.IsNotExist(err) {
 			// ignore missing files
@@ -127,19 +128,19 @@ func FindOrCreateConfigPath() string {
 	if path == "" {
 		// create the default directory if it doesn't exist
 		path = DefaultConfigPath()
-		if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
+		if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil { //nolint:gosec // pre-existing default config dir permissions; tightening these is a behavior change out of scope here
 			return ""
 		}
 
 		// write a new config file out
-		file, err := os.Create(path)
+		file, err := os.Create(path) //nolint:gosec // path is derived from the local default config directory, not attacker-controlled input
 		if err != nil {
 			return ""
 		}
-		defer file.Close()
+		defer func() { _ = file.Close() }()
 
 		logDir := DefaultLogDirectory()
-		_ = os.MkdirAll(logDir, os.ModePerm) // try and create it. Doesn't matter if it succeed or not, only byproduct will be no logs
+		_ = os.MkdirAll(logDir, os.ModePerm) //nolint:gosec // pre-existing default log dir permissions; tightening these is a behavior change out of scope here. Doesn't matter if it succeeds or not, only byproduct will be no logs
 
 		c := Root{
 			LogDirectory: logDir,
@@ -392,7 +393,7 @@ func ReadConfigFile(c *cli.Context, log *zerolog.Logger) (settings *configFileSe
 	}
 
 	log.Debug().Msgf("Loading configuration from %s", configFile)
-	file, err := os.Open(configFile)
+	file, err := os.Open(configFile) //nolint:gosec // configFile comes from the --config flag / local config search, not attacker-controlled input
 	if err != nil {
 		// If does not exist and config file was not specificly specified then return ErrNoConfigFile found.
 		if os.IsNotExist(err) && !c.IsSet("config") {
@@ -400,7 +401,7 @@ func ReadConfigFile(c *cli.Context, log *zerolog.Logger) (settings *configFileSe
 		}
 		return nil, "", err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	if err := yaml.NewDecoder(file).Decode(&configuration); err != nil {
 		if err == io.EOF {
 			log.Error().Msgf("Configuration file %s was empty", configFile)
@@ -411,7 +412,7 @@ func ReadConfigFile(c *cli.Context, log *zerolog.Logger) (settings *configFileSe
 	configuration.sourceFile = configFile
 
 	// Parse it again, with strict mode, to find warnings.
-	if file, err := os.Open(configFile); err == nil {
+	if file, err := os.Open(configFile); err == nil { //nolint:gosec // configFile comes from the --config flag / local config search, not attacker-controlled input
 		decoder := yaml.NewDecoder(file)
 		decoder.KnownFields(true)
 		var unusedConfig configFileSettings
@@ -433,7 +434,7 @@ type CustomDuration struct {
 }
 
 func (s CustomDuration) MarshalJSON() ([]byte, error) {
-	return json.Marshal(s.Duration.Seconds())
+	return json.Marshal(s.Seconds())
 }
 
 // Bounds on the number of seconds that can be converted to a time.Duration (nanoseconds)
@@ -457,7 +458,7 @@ func (s *CustomDuration) UnmarshalJSON(data []byte) error {
 }
 
 func (s *CustomDuration) MarshalYAML() (interface{}, error) {
-	return s.Duration.String(), nil
+	return s.String(), nil
 }
 
 func (s *CustomDuration) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -66,7 +66,7 @@ counters:
 `
 	var config configFileSettings
 	err := yaml.Unmarshal([]byte(rawYAML), &config)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "config-file-test", config.TunnelID)
 	assert.Equal(t, firstIngress, config.Ingress[0])
@@ -89,31 +89,30 @@ counters:
 	assert.Equal(t, ipRules, config.OriginRequest.IPRules)
 
 	retries, err := config.Int("retries")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 5, retries)
 
 	gracePeriod, err := config.Duration("grace-period")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, time.Second*30, gracePeriod)
 
 	percentage, err := config.Float64("percentage")
-	assert.NoError(t, err)
-	assert.Equal(t, 3.14, percentage)
+	require.NoError(t, err)
+	assert.InDelta(t, 3.14, percentage, 0.0001)
 
 	hostname, err := config.String("hostname")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "example.com", hostname)
 
 	tags, err := config.StringSlice("tag")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test", tags[0])
 	assert.Equal(t, "central-1", tags[1])
 
 	counters, err := config.IntSlice("counters")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 123, counters[0])
 	assert.Equal(t, 456, counters[1])
-
 }
 
 var rawJsonConfig = []byte(`
@@ -193,25 +192,25 @@ func assertConfig(
 	var config OriginRequestConfig
 	var config2 OriginRequestConfig
 
-	assert.NoError(t, json.Unmarshal(rawJsonConfig, &config))
+	require.NoError(t, json.Unmarshal(rawJsonConfig, &config))
 
 	assert.Equal(t, time.Second*10, config.ConnectTimeout.Duration)
 	assert.Equal(t, time.Second*30, config.TLSTimeout.Duration)
 	assert.Equal(t, time.Second*30, config.TCPKeepAlive.Duration)
-	assert.Equal(t, true, *config.NoHappyEyeballs)
+	assert.True(t, *config.NoHappyEyeballs)
 	assert.Equal(t, time.Second*60, config.KeepAliveTimeout.Duration)
 	assert.Equal(t, 10, *config.KeepAliveConnections)
 	assert.Equal(t, "app.tunnel.com", *config.HTTPHostHeader)
 	assert.Equal(t, "app.tunnel.com", *config.OriginServerName)
 	assert.Equal(t, "/etc/capool", *config.CAPool)
-	assert.Equal(t, true, *config.NoTLSVerify)
-	assert.Equal(t, true, *config.DisableChunkedEncoding)
-	assert.Equal(t, true, *config.BastionMode)
+	assert.True(t, *config.NoTLSVerify)
+	assert.True(t, *config.DisableChunkedEncoding)
+	assert.True(t, *config.BastionMode)
 	assert.Equal(t, "127.0.0.3", *config.ProxyAddress)
-	assert.Equal(t, true, *config.NoTLSVerify)
+	assert.True(t, *config.NoTLSVerify)
 	assert.Equal(t, uint(9000), *config.ProxyPort)
 	assert.Equal(t, "socks", *config.ProxyType)
-	assert.Equal(t, true, *config.Http2Origin)
+	assert.True(t, *config.Http2Origin)
 
 	privateV4 := "10.0.0.0/8"
 	privateV6 := "fc00::/7"

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -147,6 +148,25 @@ var rawJsonConfig = []byte(`
 	"http2Origin": true
 }
 `)
+
+func TestCustomDurationUnmarshalJSONOverflow(t *testing.T) {
+	var d CustomDuration
+
+	// A caller mistakenly supplying nanoseconds (as documented for time.Duration
+	// generally) instead of the seconds this type actually expects overflows
+	// int64 when multiplied by time.Second. This must be a clear error, not a
+	// silently wrapped negative duration that causes dials to fail instantly.
+	err := json.Unmarshal([]byte("10000000000"), &d)
+	require.Error(t, err)
+
+	require.NoError(t, json.Unmarshal([]byte("10"), &d))
+	assert.Equal(t, 10*time.Second, d.Duration)
+
+	require.NoError(t, json.Unmarshal([]byte(fmt.Sprintf("%d", maxDurationSeconds)), &d))
+	assert.Equal(t, time.Duration(maxDurationSeconds)*time.Second, d.Duration)
+
+	require.Error(t, json.Unmarshal([]byte(fmt.Sprintf("%d", maxDurationSeconds+1)), &d))
+}
 
 func TestMarshalUnmarshalOriginRequest(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
## Summary
- `CustomDuration.UnmarshalJSON` (`config/configuration.go`) parses the JSON wire value as **seconds**, then multiplies by `time.Second` to build a `time.Duration`. This is intentional (see the comment above `CustomDuration`) so remote/API-pushed configs aren't limited by JS's 32-bit-safe-integer nanosecond convention, and it's mirrored by existing tests (`TestMarshalUnmarshalOriginRequest`).
- However there was no bounds check: a caller supplying a value on the order of `1e10` (e.g. assuming nanoseconds, the usual `time.Duration` convention) overflows `int64` when multiplied by `1e9`, silently wrapping into a large **negative** `time.Duration`.
- That negative duration flows straight into `net.Dialer.Timeout` for `originRequest.connectTimeout` (and any other `CustomDuration` field arriving via remote JSON config). A negative/expired deadline makes `net.Dialer.DialContext` fail instantly with `dial tcp: ... i/o timeout` — before any `socket()`/`connect()` syscall — with no indication that the *config value* was the problem.
- This fix bounds-checks the parsed seconds value against the safe `int64` range before multiplying, returning a clear unmarshal error instead of silently producing a corrupted, confusing timeout.
- Also fixes pre-existing lint issues (errcheck, staticcheck, testifylint, gosec) in the two touched files - this repo's `.golangci.yaml` sets `whole-files: true`, so editing a file surfaces lint findings across the entire file, not just the diff.

## Test plan
- [x] Added `TestCustomDurationUnmarshalJSONOverflow` in `config/configuration_test.go` covering: the reported repro value, a normal value, the boundary value, and one past the boundary.
- [x] `go build ./...`
- [x] `go test -race ./config/... ./orchestration/...`
- [x] `gofmt -l` / `go vet ./config/...`
- [x] `make lint` (`golangci-lint run ./config/...` -> 0 issues)

Fixes #1702