### PR TITLE
fix: TestSupportedCurvesNegotiation fails with standard Go on Linux

### DIFF
--- a/crypto/curves_test.go
+++ b/crypto/curves_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"net/http"
 	"net/http/httptest"
-	"runtime"
 	"slices"
 	"testing"
 
@@ -113,14 +112,15 @@ func TestSupportedCurvesNegotiation(t *testing.T) {
 		curves, err := getCurvePreferences(tcase)
 		require.NoError(t, err)
 		advertisedCurves := runClientServerHandshake(t, curves)
-		require.True(t, slices.Contains(advertisedCurves, tls.CurveP256))
-		require.True(t, slices.Contains(advertisedCurves, tls.X25519MLKEM768))
-		expectedLength := 2
-		if runtime.GOOS == "linux" {
-			// P256Kyber768Draft00 only exists in linux
-			require.True(t, slices.Contains(advertisedCurves, P256Kyber768Draft00))
-			expectedLength = 3
+
+		// P256Kyber768Draft00 is a private curve ID implemented by
+		// Cloudflare's Go fork. Standard Go's crypto/tls filters it out of
+		// the ClientHello, so its presence -- not the OS -- determines which
+		// toolchain produced the handshake.
+		expectedCurves := []tls.CurveID{tls.X25519MLKEM768, tls.CurveP256}
+		if slices.Contains(advertisedCurves, P256Kyber768Draft00) {
+			expectedCurves = curves
 		}
-		require.Len(t, advertisedCurves, expectedLength)
+		require.Equal(t, expectedCurves, advertisedCurves)
 	}
 }


### PR DESCRIPTION
## Summary
- `TestSupportedCurvesNegotiation` used `runtime.GOOS == "linux"` as a proxy for whether the TLS stack supports Cloudflare's private `P256Kyber768Draft00` curve. That curve is implemented by Cloudflare's Go fork, not by the standard `crypto/tls` package, so the test fails under a standard Go toolchain on Linux (the setup documented in the README for external contributors).
- Standard Go filters the unknown private curve ID out of the ClientHello entirely, so the assertion that it must be present fails.

## Fix
- Detect the toolchain by checking whether `P256Kyber768Draft00` actually appears in the advertised curves, rather than inferring it from `GOOS`.
- Compare against the full expected ordered sequence in both cases, preserving exact-order validation.

## Test plan
- [x] `go test -mod=vendor -race -count=1 -run TestSupportedCurvesNegotiation -v ./crypto` passes on standard Go 1.26.0 linux/arm64
- [x] `go test -mod=vendor -race -count=1 -v ./crypto/...` passes (full package)
- [x] `go vet ./crypto/...`
- [x] `go build ./...`

Fixes #1700