### PR TITLE
Fix FreeBSD build by defining createTokenFile

### DIFF
--- a/cmd/cloudflared/freebsd_service.go
+++ b/cmd/cloudflared/freebsd_service.go
@@ -1,0 +1,5 @@
+//go:build freebsd
+
+package main
+
+var createTokenFile = createTokenFileUnix


### PR DESCRIPTION
Need issues #1365 patch first.

## Summary

Building `cloudflared` on FreeBSD currently fails with:

```text
cmd/cloudflared/common_service.go:56:12: undefined: createTokenFile
```

This worked around mid-July 2026, but no longer builds on the current HEAD.

## Environment

- OS: FreeBSD 14 and 15 (amd64)
- Build command:

```sh
gmake cloudflared
```

## Cause

`createTokenFile` is defined for Linux, macOS, and Windows, but there is no corresponding definition for FreeBSD.

Current implementations:

- `cmd/cloudflared/linux_service.go`
- `cmd/cloudflared/macos_service.go`
- `cmd/cloudflared/windows_service.go`

FreeBSD is missing an equivalent definition.

## Fix

Adding the following file restores the build successfully:

`cmd/cloudflared/freebsd_service.go`

```go
//go:build freebsd

package main

var createTokenFile = createTokenFileUnix
```

## Verification

After adding the file:

- `gmake cloudflared` completes successfully.
- The resulting `cloudflared` binary starts correctly.
- Basic tunnel operation has been verified on FreeBSD.

This change only affects FreeBSD builds and does not modify behavior on other platforms.