### PR TITLE
fix: return 400 instead of 502 for a Host header with a non-numeric port

### DIFF
--- a/connection/quic_connection.go
+++ b/connection/quic_connection.go
@@ -39,6 +39,16 @@ const (
 	QUICMetadataFlowID = "FlowID"
 )
 
+// malformedRequestError indicates the request could not be built because of client-supplied data, such as a
+// Host header with a non-numeric port. It is reported to the eyeball as a 400 rather than a 502, since the
+// failure is not caused by the origin or the connection to it.
+type malformedRequestError struct {
+	cause error
+}
+
+func (e *malformedRequestError) Error() string { return e.cause.Error() }
+func (e *malformedRequestError) Unwrap() error { return e.cause }
+
 // quicConnection represents the type that facilitates Proxying via QUIC streams.
 type quicConnection struct {
 	conn                 cfdquic.QUICConnection
@@ -206,6 +216,10 @@ func (q *quicConnection) handleDataStream(ctx context.Context, stream *rpcquic.R
 		if errors.Is(err, cfdflow.ErrTooManyActiveFlows) {
 			metadata = append(metadata, pogs.ErrorFlowConnectRateLimitedMetadata)
 		}
+		var malformedErr *malformedRequestError
+		if errors.As(err, &malformedErr) {
+			metadata = append(metadata, pogs.Metadata{Key: HTTPStatus, Val: strconv.Itoa(http.StatusBadRequest)})
+		}
 
 		if writeRespErr := stream.WriteConnectResponseData(err, metadata...); writeRespErr != nil {
 			return writeRespErr
@@ -352,7 +366,7 @@ func buildHTTPRequest(
 
 	req, err := http.NewRequestWithContext(ctx, method, dest, body)
 	if err != nil {
-		return nil, err
+		return nil, &malformedRequestError{cause: err}
 	}
 
 	req.Host = host

--- a/connection/quic_connection.go
+++ b/connection/quic_connection.go
@@ -39,15 +39,9 @@ const (
 	QUICMetadataFlowID = "FlowID"
 )
 
-// malformedRequestError indicates the request could not be built because of client-supplied data, such as a
-// Host header with a non-numeric port. It is reported to the eyeball as a 400 rather than a 502, since the
-// failure is not caused by the origin or the connection to it.
-type malformedRequestError struct {
-	cause error
-}
-
-func (e *malformedRequestError) Error() string { return e.cause.Error() }
-func (e *malformedRequestError) Unwrap() error { return e.cause }
+// errMalformedRequest marks a buildHTTPRequest failure caused by client-supplied data, such as a Host
+// header with a non-numeric port, so it is reported to the eyeball as 400 instead of the default 502.
+var errMalformedRequest = errors.New("malformed request")
 
 // quicConnection represents the type that facilitates Proxying via QUIC streams.
 type quicConnection struct {
@@ -216,8 +210,7 @@ func (q *quicConnection) handleDataStream(ctx context.Context, stream *rpcquic.R
 		if errors.Is(err, cfdflow.ErrTooManyActiveFlows) {
 			metadata = append(metadata, pogs.ErrorFlowConnectRateLimitedMetadata)
 		}
-		var malformedErr *malformedRequestError
-		if errors.As(err, &malformedErr) {
+		if errors.Is(err, errMalformedRequest) {
 			metadata = append(metadata, pogs.Metadata{Key: HTTPStatus, Val: strconv.Itoa(http.StatusBadRequest)})
 		}
 
@@ -366,7 +359,7 @@ func buildHTTPRequest(
 
 	req, err := http.NewRequestWithContext(ctx, method, dest, body)
 	if err != nil {
-		return nil, &malformedRequestError{cause: err}
+		return nil, fmt.Errorf("%w: %s", errMalformedRequest, err)
 	}
 
 	req.Host = host

--- a/connection/quic_connection_test.go
+++ b/connection/quic_connection_test.go
@@ -511,7 +511,7 @@ func TestBuildHTTPRequest(t *testing.T) {
 }
 
 // TestBuildHTTPRequestMalformedDest verifies that a Dest containing a non-numeric port (e.g. forwarded
-// verbatim from a client's malformed Host header) is reported as malformedRequestError, not a bare error,
+// verbatim from a client's malformed Host header) is reported as errMalformedRequest, not a bare error,
 // so that callers can distinguish a bad request from an origin/proxy failure.
 func TestBuildHTTPRequestMalformedDest(t *testing.T) {
 	log := zerolog.Nop()
@@ -524,10 +524,7 @@ func TestBuildHTTPRequestMalformedDest(t *testing.T) {
 	}
 
 	_, err := buildHTTPRequest(t.Context(), connectRequest, io.NopCloser(&bytes.Buffer{}), 0, &log)
-	require.Error(t, err)
-
-	var malformedErr *malformedRequestError
-	require.ErrorAs(t, err, &malformedErr)
+	require.ErrorIs(t, err, errMalformedRequest)
 }
 
 func (moc *mockOriginProxyWithRequest) ProxyTCP(ctx context.Context, rwa ReadWriteAcker, tcpRequest *TCPRequest) error {

--- a/connection/quic_connection_test.go
+++ b/connection/quic_connection_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -509,6 +510,26 @@ func TestBuildHTTPRequest(t *testing.T) {
 	}
 }
 
+// TestBuildHTTPRequestMalformedDest verifies that a Dest containing a non-numeric port (e.g. forwarded
+// verbatim from a client's malformed Host header) is reported as malformedRequestError, not a bare error,
+// so that callers can distinguish a bad request from an origin/proxy failure.
+func TestBuildHTTPRequestMalformedDest(t *testing.T) {
+	log := zerolog.Nop()
+	connectRequest := &pogs.ConnectRequest{
+		Dest: "http://test.com:aaaa/foo",
+		Metadata: []pogs.Metadata{
+			{Key: "HttpHost", Val: "test.com:aaaa"},
+			{Key: "HttpMethod", Val: "get"},
+		},
+	}
+
+	_, err := buildHTTPRequest(t.Context(), connectRequest, io.NopCloser(&bytes.Buffer{}), 0, &log)
+	require.Error(t, err)
+
+	var malformedErr *malformedRequestError
+	require.ErrorAs(t, err, &malformedErr)
+}
+
 func (moc *mockOriginProxyWithRequest) ProxyTCP(ctx context.Context, rwa ReadWriteAcker, tcpRequest *TCPRequest) error {
 	if tcpRequest.Dest == "rate-limit-me" {
 		return pkgerrors.Wrap(cfdflow.ErrTooManyActiveFlows, "failed tcp stream")
@@ -643,6 +664,63 @@ func TestTCPProxy_FlowRateLimited(t *testing.T) {
 		// Got Rate Limited
 		assert.NotEmpty(t, response.Error)
 		assert.Contains(t, response.Metadata, pogs.ErrorFlowConnectRateLimitedMetadata)
+	}()
+
+	tunnelConn, _ := testTunnelConnection(t, netip.MustParseAddrPort(udpListener.LocalAddr().String()), uint8(0))
+
+	connDone := make(chan struct{})
+	go func() {
+		defer close(connDone)
+		_ = tunnelConn.Serve(ctx)
+	}()
+
+	<-serverDone
+	cancel()
+	<-connDone
+}
+
+// TestHTTPProxy_MalformedHostPort tests that a Dest with a non-numeric port (as would be forwarded from a
+// client's malformed Host header) results in a 400 response to the eyeball instead of the default 502.
+func TestHTTPProxy_MalformedHostPort(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	// Start a UDP Listener for QUIC.
+	udpAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	udpListener, err := net.ListenUDP(udpAddr.Network(), udpAddr)
+	require.NoError(t, err)
+	defer func() { _ = udpListener.Close() }()
+
+	quicTransport := &quic.Transport{Conn: udpListener, ConnectionIDLength: 16}
+	quicListener, err := quicTransport.Listen(testTLSServerConfig, testQUICConfig)
+	require.NoError(t, err)
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+
+		session, err := quicListener.Accept(ctx)
+		assert.NoError(t, err)
+
+		quicStream, err := session.OpenStreamSync(t.Context())
+		assert.NoError(t, err)
+		stream := cfdquic.NewSafeStreamCloser(quicStream, defaultQUICTimeout, &log)
+
+		reqClientStream := rpcquic.RequestClientStream{ReadWriteCloser: stream}
+		err = reqClientStream.WriteConnectRequestData(
+			"http://test.com:aaaa/foo",
+			pogs.ConnectionTypeHTTP,
+			pogs.Metadata{Key: HTTPHostKey, Val: "test.com:aaaa"},
+			pogs.Metadata{Key: HTTPMethodKey, Val: "GET"},
+		)
+		assert.NoError(t, err)
+
+		response, err := reqClientStream.ReadConnectResponseData()
+		assert.NoError(t, err)
+
+		assert.NotEmpty(t, response.Error)
+		assert.Contains(t, response.Metadata, pogs.Metadata{Key: HTTPStatus, Val: strconv.Itoa(http.StatusBadRequest)})
 	}()
 
 	tunnelConn, _ := testTunnelConnection(t, netip.MustParseAddrPort(udpListener.LocalAddr().String()), uint8(0))


### PR DESCRIPTION
## Summary
- The QUIC data-path `ConnectRequest.Dest` can carry the eyeball's Host header verbatim, so a request with `Host: app.example.com:aaaa` produces a `Dest` like `http://app.example.com:aaaa/...`.
- `buildHTTPRequest` passes this straight into `http.NewRequestWithContext`, which fails Go's URL parser with `invalid port ":aaaa" after host` since the port isn't numeric.
- That error propagated up through `dispatchRequest`/`handleDataStream` with no distinguishing metadata, so it was reported to the eyeball as a bare error with the default 502 status — indistinguishable from a genuine origin/proxy failure, and misleading for anyone debugging the client-side issue.

## Fix
- Wrap the `http.NewRequestWithContext` error in a new `malformedRequestError` type when it fails to build the request from `Dest`.
- In `handleDataStream`, detect this error type (same pattern already used for `cfdflow.ErrTooManyActiveFlows`) and attach `HttpStatus: 400` metadata so the eyeball gets a 400 instead of a 502.

## Test plan
- [x] Added `TestBuildHTTPRequestMalformedDest` verifying a Dest with a non-numeric port returns `malformedRequestError`.
- [x] Added `TestHTTPProxy_MalformedHostPort`, an end-to-end QUIC test verifying the response metadata carries `HttpStatus: 400`.
- [x] `go build ./...`
- [x] `go vet ./connection/...`
- [x] `go test -race -count=1 ./connection/...`
- [x] `golangci-lint run ./connection/...` -> 0 issues

Fixes #1490