### PR TITLE
fix: bump quic-go fork pin to include the CVE-2025-59530 fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -109,4 +109,4 @@ replace github.com/prometheus/golang_client => github.com/prometheus/golang_clie
 replace gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.1
 
 // This fork is based on quic-go v0.45
-replace github.com/quic-go/quic-go => github.com/chungthuang/quic-go v0.45.1-0.20250428085412-43229ad201fd
+replace github.com/quic-go/quic-go => github.com/stareezy-1/quic-go v0.0.0-20260806091559-d3ee2305a943

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ github.com/bytedance/sonic/loader v0.2.0 h1:zNprn+lsIP06C/IqCHs3gPQIvnvpKbbxyXQP
 github.com/bytedance/sonic/loader v0.2.0/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chungthuang/quic-go v0.45.1-0.20250428085412-43229ad201fd h1:VdYI5zFQ2h1/qzoC6rhyPx479bkF8i177Qpg4Q2n1vk=
-github.com/chungthuang/quic-go v0.45.1-0.20250428085412-43229ad201fd/go.mod h1:MFlGGpcpJqRAfmYi6NC2cptDPSxRWTOGNuP4wqrWmzQ=
 github.com/cloudflare/backoff v0.0.0-20240920015135-e46b80a3a7d0 h1:pRcxfaAlK0vR6nOeQs7eAEvjJzdGXl8+KaBlcvpQTyQ=
 github.com/cloudflare/backoff v0.0.0-20240920015135-e46b80a3a7d0/go.mod h1:rzgs2ZOiguV6/NpiDgADjRLPNyZlApIWxKpkT+X8SdY=
 github.com/cloudwego/base64x v0.1.4 h1:jwCgWpFanWmN8xoIUHa2rtzmkd5J2plF/dnLS6Xd/0Y=
@@ -189,6 +187,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/shirou/gopsutil/v4 v4.26.3 h1:2ESdQt90yU3oXF/CdOlRCJxrP+Am1aBYubTMTfxJ1qc=
 github.com/shirou/gopsutil/v4 v4.26.3/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/stareezy-1/quic-go v0.0.0-20260806091559-d3ee2305a943 h1:67fF8SB/JinU0QavrnZ8I3+J6GMtK2b1I2IMQfUdF3U=
+github.com/stareezy-1/quic-go v0.0.0-20260806091559-d3ee2305a943/go.mod h1:MFlGGpcpJqRAfmYi6NC2cptDPSxRWTOGNuP4wqrWmzQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/vendor/github.com/quic-go/quic-go/connection.go
+++ b/vendor/github.com/quic-go/quic-go/connection.go
@@ -851,6 +851,13 @@ func (s *connection) handleHandshakeComplete(now time.Time) error {
 }
 
 func (s *connection) handleHandshakeConfirmed(now time.Time) error {
+	// Drop initial keys.
+	// On the client side, this should have happened when sending the first Handshake packet,
+	// but this is not guaranteed if the server misbehaves.
+	// See CVE-2025-59530 for more details.
+	if err := s.dropEncryptionLevel(protocol.EncryptionInitial, now); err != nil {
+		return err
+	}
 	if err := s.dropEncryptionLevel(protocol.EncryptionHandshake, now); err != nil {
 		return err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -203,7 +203,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/quic-go/quic-go v0.52.0 => github.com/chungthuang/quic-go v0.45.1-0.20250428085412-43229ad201fd
+# github.com/quic-go/quic-go v0.52.0 => github.com/stareezy-1/quic-go v0.0.0-20260806091559-d3ee2305a943
 ## explicit; go 1.23
 github.com/quic-go/quic-go
 github.com/quic-go/quic-go/internal/ackhandler
@@ -571,4 +571,4 @@ zombiezen.com/go/capnproto2/std/capnp/rpc
 # github.com/urfave/cli/v2 => github.com/ipostelnik/cli/v2 v2.3.1-0.20210324024421-b6ea8234fe3d
 # github.com/prometheus/golang_client => github.com/prometheus/golang_client v1.12.1
 # gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.1
-# github.com/quic-go/quic-go => github.com/chungthuang/quic-go v0.45.1-0.20250428085412-43229ad201fd
+# github.com/quic-go/quic-go => github.com/stareezy-1/quic-go v0.0.0-20260806091559-d3ee2305a943


### PR DESCRIPTION
## Summary

Fixes https://github.com/cloudflare/cloudflared/issues/1709

## Problem

The `replace` directive pins the QUIC stack to a fork based on quic-go v0.45, which predates the fix for **CVE-2025-59530** (GHSA-47m2-4cr7-mhcw, 7.5). A server that sends HANDSHAKE_DONE before the handshake actually finishes makes the client drop Handshake keys before Initial keys; the next undecryptable packet then trips the "no packets are queued after completion of the handshake" assert — a remote crash for cloudflared as the QUIC client.

Fuller `quic-go` upgrades (v0.59.1) were landed and reverted twice before releases, so this PR takes the backport path suggested in the issue analysis: the fork pin is bumped to a commit that applies quic-go#5354 onto the **exact previously-pinned fork state**. The only source change is the 7-line fix in `connection.go` (drop initial keys when the handshake is confirmed) — no API migration.

## Changes

- `go.mod` / `go.sum`: fork pin bumped to `stareezy-1/quic-go v0.0.0-20260806091559-d3ee2305a943` (pinned fork state + backport).
- `vendor/github.com/quic-go/quic-go/connection.go`: the backported fix (verified as the only vendored source change).
- Companion upstream PR: https://github.com/chungthuang/quic-go/pull/16 — once an equivalent commit lands on the fork's `cloudflare` branch, the replace should be flipped back to `chungthuang/quic-go` at that commit.

## Verification

- `go build ./...` passes.
- `go test ./quic/...` passes (both packages).
- The vendored diff vs the previous pin is exactly the 7-line fix.

## Notes

- The pin currently points at a personal fork commit solely because the backported commit does not exist on `chungthuang/quic-go` yet; it carries the identical module path and fork state.
