### PR TITLE
fix: exit non-zero when CLI flag/env parsing fails

### DIFF
--- a/cmd/cloudflared/generic_service.go
+++ b/cmd/cloudflared/generic_service.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	cli "github.com/urfave/cli/v2"
 
@@ -28,7 +27,7 @@ func runApp(app *cli.App, graceShutdownC chan struct{}) {
 			},
 		},
 	})
-	app.Run(os.Args)
+	runAppAndExit(app)
 }
 
 func installGenericService(c *cli.Context) error {

--- a/cmd/cloudflared/linux_service.go
+++ b/cmd/cloudflared/linux_service.go
@@ -51,7 +51,7 @@ out if no configuration file with credentials was found).`,
 			},
 		},
 	})
-	_ = app.Run(os.Args)
+	runAppAndExit(app)
 }
 
 // The directory and files that are used by the service.

--- a/cmd/cloudflared/macos_service.go
+++ b/cmd/cloudflared/macos_service.go
@@ -50,7 +50,7 @@ causing it to look for credentials in a configuration file upon startup.`,
 			},
 		},
 	})
-	_ = app.Run(os.Args)
+	runAppAndExit(app)
 }
 
 func newLaunchdTemplate(installPath, stdoutPath, stderrPath string) *ServiceTemplate {

--- a/cmd/cloudflared/main_test.go
+++ b/cmd/cloudflared/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMain doubles as the helper-process entry point: when
+// GO_WANT_HELPER_PROCESS is set, the test binary re-executes main() so tests
+// can assert on the process exit code, which plain unit tests cannot.
+func TestMain(m *testing.M) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") == "1" {
+		main()
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+// Regression test for https://github.com/cloudflare/cloudflared/issues/1606:
+// an invalid TUNNEL_GRACE_PERIOD value used to make cloudflared exit 0 with no
+// output, because runApp discarded the error from app.Run. It must now print
+// the parse error and exit non-zero.
+func TestRunAppInvalidGracePeriodEnvExitsNonZero(t *testing.T) {
+	//nolint:gosec // G204: re-executes this test binary (os.Args[0]) with a fixed command line to assert the exit code
+	cmd := exec.Command(os.Args[0], "tunnel", "run")
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_HELPER_PROCESS=1",
+		"TUNNEL_GRACE_PERIOD=10",
+	)
+	out, err := cmd.CombinedOutput()
+
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr, "expected a non-zero exit code, got: %s", out)
+	assert.NotZero(t, exitErr.ExitCode())
+	assert.Contains(t, string(out), "grace-period")
+}

--- a/cmd/cloudflared/run_app.go
+++ b/cmd/cloudflared/run_app.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v2"
+)
+
+// runAppAndExit runs the CLI app and exits with a non-zero status when it
+// fails. Flag and env-var parse errors (e.g. an invalid TUNNEL_GRACE_PERIOD)
+// are returned by app.Run without being printed, so ignoring the error used
+// to make cloudflared exit 0 with no output (see #1606). Print the error to
+// stderr and exit 1 so scripts and service managers can detect the failure.
+func runAppAndExit(app *cli.App) {
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/cloudflared/windows_service.go
+++ b/cmd/cloudflared/windows_service.go
@@ -94,7 +94,7 @@ causing it to look for credentials in a configuration file upon startup.`,
 		log.Fatal().Err(err).Msg("failed to determine if we are running in an interactive session")
 	}
 	if isIntSess {
-		app.Run(os.Args)
+		runAppAndExit(app)
 		return
 	}
 
@@ -106,7 +106,7 @@ causing it to look for credentials in a configuration file upon startup.`,
 		if errno, ok := err.(syscall.Errno); ok && int(errno) == serviceControllerConnectionFailure {
 			// Hack: assume this is a false negative from the IsAnInteractiveSession() check above.
 			// Run the app in "interactive" mode anyway.
-			app.Run(os.Args)
+			runAppAndExit(app)
 			return
 		}
 		log.Fatal().Err(err).Msgf("%s service failed", windowsServiceName)


### PR DESCRIPTION
## Summary

`cloudflared` exits with status 0 and no output when a flag or environment
variable fails to parse, e.g. `TUNNEL_GRACE_PERIOD=10` (see #1606).

## Problem

`TUNNEL_GRACE_PERIOD=10` (missing the duration unit) fails
`time.ParseDuration` inside urfave/cli's flag setup. `App.Run` returns that
error **without printing anything**, and all four `runApp` implementations
discarded the returned error:

```go
app.Run(os.Args)      // generic, windows (interactive)
_ = app.Run(os.Args)  // linux, macos
```

so the process exited 0 silently. The same discard made the CLI case
(`cloudflared tunnel --grace-period 10 run`) exit 0 after printing
"Incorrect Usage", which breaks scripts and service managers that rely on
the exit status. The issue also reports `systemd` reporting a confusing
"protocol" failure.

## Fix

- New `runAppAndExit` helper (cmd/cloudflared/run_app.go): runs the app,
  prints any returned error to stderr, and exits 1.
- All four `runApp` implementations (generic/linux/macos/windows) now use
  it instead of discarding the error.

Behavior before → after:

| Invocation | Before | After |
| --- | --- | --- |
| `TUNNEL_GRACE_PERIOD=10 cloudflared tunnel run` | exit 0, no output | exit 1, `could not parse "10" as duration value for flag grace-period: time: missing unit in duration "10"` |
| `cloudflared tunnel --grace-period 10 run` | exit 0 | exit 1 |
| `cloudflared --version` / `--help` | exit 0 | exit 0 (unchanged) |

## Tests

- New regression test `TestRunAppInvalidGracePeriodEnvExitsNonZero`
  (cmd/cloudflared/main_test.go): re-executes the test binary with
  `TUNNEL_GRACE_PERIOD=10` via the helper-process pattern and asserts a
  non-zero exit code plus the error message. Fails without the fix (exit 0),
  passes with it.
- `make test` (go test -race ./...): 940 packages pass, 0 failures.
- `go vet ./cmd/cloudflared/` clean; `golangci-lint` reports no new issues
  in the touched files.