### PR TITLE
fix: use 'auto' as default protocol for quick tunnels

### DIFF
--- a/cmd/cloudflared/tunnel/quick_tunnel.go
+++ b/cmd/cloudflared/tunnel/quick_tunnel.go
@@ -84,7 +84,7 @@ func RunQuickTunnel(sc *subcommandContext) error {
 	}
 
 	if !sc.c.IsSet(flags.Protocol) {
-		_ = sc.c.Set(flags.Protocol, "quic")
+		_ = sc.c.Set(flags.Protocol, "auto")
 	}
 
 	// Override the number of connections used. Quick tunnels shouldn't be used for production usage,


### PR DESCRIPTION
## Problem

Quick tunnels (`cloudflared tunnel --url ...`) hardcode `quic` as the default protocol when `--protocol` is not specified:

```go
if !sc.c.IsSet(flags.Protocol) {
    _ = sc.c.Set(flags.Protocol, "quic")  // ← always QUIC
}
```

The [official docs](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/run-parameters/#protocol) state that `auto` is the default protocol, which lets cloudflared negotiate the best available protocol.

This means users running quick tunnels in environments where QUIC is blocked (firewalls, some corporate networks) will get connection failures instead of a graceful HTTP/2 fallback.

## Fix

One-line change: `"quic"` → `"auto"`

```go
if !sc.c.IsSet(flags.Protocol) {
    _ = sc.c.Set(flags.Protocol, "auto")  // ← matches documented default
}
```

Fixes #1609.

---
Restored after an accidental fork deletion. Same commits as #1627.