### PR TITLE
chore: log warning when token auth URL companion file write fails

### DIFF
--- a/token/transfer.go
+++ b/token/transfer.go
@@ -41,7 +41,9 @@ func RunTransfer(transferURL *url.URL, appAUD, resourceName, key, value string, 
 
 	// write auth URL to companion file so other waiting processes can display it
 	if urlFilePath != "" {
-		_ = os.WriteFile(urlFilePath, []byte(requestURL), 0600) // nolint: gosec
+		if err := os.WriteFile(urlFilePath, []byte(requestURL), 0600); err != nil { //nolint:gosec
+			log.Warn().Err(err).Msgf("Failed to write request URL to %s", urlFilePath)
+		}
 	}
 
 	// See AUTH-1423 for why we use stderr (the way git wraps ssh)


### PR DESCRIPTION
## Why
  `RunTransfer` writes the generated auth URL to a companion file so other waiting processes can display it. The write error was silently discarded (`_ =`), making it hard to diagnose
  failures in the browser-based token flow.

  ## What
  Replace the silent discard with a zerolog `Warn` that includes the file path and error. The write is still non-fatal — a failure here doesn't break the auth flow itself.

  ## Testing
  Existing token package tests pass.