### PR TITLE
chore: remove debug fmt.Println from datagramsession test helper

### DIFF
--- a/datagramsession/manager_test.go
+++ b/datagramsession/manager_test.go
@@ -265,7 +265,6 @@ func (me *mockEyeballSession) serve(ctx context.Context, requestChan chan *packe
 		if !bytes.Equal(resp, me.expectedResponse) {
 			return fmt.Errorf("Expect %v, read %v", me.expectedResponse, resp)
 		}
-		fmt.Println("Resp", resp)
 	}
 	return nil
 }


### PR DESCRIPTION
## Why
  `mockEyeballSession.serve` was printing raw response bytes to stdout on every iteration. This produces noisy output when running `go test ./datagramsession/...` and was clearly a
  debug leftover — the equality assertion just above it already handles correctness.

  ## What
  Remove the `fmt.Println("Resp", resp)` line.

  ## Testing
  `go test ./datagramsession/...` passes.