### PR TITLE
Fix Windows self-update reporting success while leaving cloudflared.exe missing

### DIFF
--- a/cmd/cloudflared/updater/workers_update.go
+++ b/cmd/cloudflared/updater/workers_update.go
@@ -2,6 +2,7 @@ package updater
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"errors"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"text/template"
 	"time"
 
@@ -23,18 +25,37 @@ import (
 
 const (
 	clientTimeout = time.Second * 60
-	// stop the service
-	// rename cloudflared.exe to cloudflared.exe.old
-	// rename cloudflared.exe.new to cloudflared.exe
-	// delete cloudflared.exe.old
-	// start the service
-	// exit with code 0 if we've reached this point indicating success.
-	windowsUpdateCommandTemplate = `sc stop cloudflared >nul 2>&1
-del "{{.OldPath}}"
+	// "net stop", unlike "sc stop", blocks until the service has actually
+	// stopped, so cloudflared.exe is guaranteed to be free of the service's
+	// file handle before the renames below run. This process (cloudflared.exe
+	// update) is itself an instance of the binary being replaced, so it must
+	// launch this script and exit almost immediately afterwards (see
+	// runWindowsBatch): Windows can rename a running executable, but only
+	// once nothing is left waiting on this process to finish, which is why
+	// the short sleep below exists as a safety margin. If a rename fails
+	// partway through, the script restores the original binary rather than
+	// leaving the install without an executable.
+	windowsUpdateCommandTemplate = `net stop cloudflared >nul 2>&1
+ping -n 2 127.0.0.1 >nul
+if exist "{{.OldPath}}" del /f /q "{{.OldPath}}"
 rename "{{.TargetPath}}" {{.OldName}}
+if errorlevel 1 goto fail
 rename "{{.NewPath}}" {{.BinaryName}}
+if errorlevel 1 goto restore
+del /f /q "{{.OldPath}}" >nul 2>&1
 sc start cloudflared >nul 2>&1
-exit /b 0`
+del "%~f0"
+exit /b 0
+:restore
+rename "{{.OldPath}}" {{.BinaryName}}
+sc start cloudflared >nul 2>&1
+del "%~f0"
+exit /b 1
+:fail
+sc start cloudflared >nul 2>&1
+del "%~f0"
+exit /b 1
+`
 	batchFileName = "cfd_update.bat"
 )
 
@@ -124,6 +145,12 @@ func (v *WorkersVersion) Apply() error {
 		}
 		rootDir := filepath.Dir(v.targetPath)
 		batchPath := filepath.Join(rootDir, batchFileName)
+		// runWindowsBatch starts the script and returns without waiting for
+		// it, so Apply() (and everything above it, up through the update
+		// command's Action) must return promptly: this process is running
+		// the very binary the script is about to rename, and Windows won't
+		// let that rename go through while something is still waiting on
+		// this process.
 		return runWindowsBatch(batchPath)
 	}
 
@@ -209,8 +236,12 @@ func isCompressedFile(urlstring string) bool {
 	return path.Ext(u.Path) == ".tgz"
 }
 
-// writeBatchFile writes a batch file out to disk
-// see the dicussion on why it has to be done this way
+// writeBatchFile writes a batch file out to disk.
+// See the discussion on why it has to be done this way in runWindowsBatch.
+//
+// The rendered script is normalized to CRLF line endings: cmd.exe's parser
+// has known issues with GOTOs/labels in a script that has Unix line endings,
+// and this template relies on both.
 func writeBatchFile(targetPath string, newPath string, oldPath string) error {
 	batchFilePath := filepath.Join(filepath.Dir(targetPath), batchFileName)
 	os.Remove(batchFilePath) //remove any failed updates before download
@@ -235,20 +266,33 @@ func writeBatchFile(targetPath string, newPath string, oldPath string) error {
 	if err != nil {
 		return err
 	}
-	return t.Execute(f, data)
+	var rendered bytes.Buffer
+	if err := t.Execute(&rendered, data); err != nil {
+		return err
+	}
+	normalized := strings.ReplaceAll(rendered.String(), "\r\n", "\n")
+	normalized = strings.ReplaceAll(normalized, "\n", "\r\n")
+	_, err = f.WriteString(normalized)
+	return err
 }
 
-// run each OS command for windows
+// runWindowsBatch starts (but does not wait for) the update batch script.
+//
+// This process is cloudflared.exe update, an instance of the very binary the
+// script needs to rename away. Renaming a running executable only works once
+// nothing is left waiting on that process to exit, so this function must not
+// block on the script the way an ordinary shell-out would: if it did (as it
+// used to, via cmd.Output()), this process would sit here holding the update
+// open until the script's "net stop"/rename/"sc start" sequence finished, and
+// the rename of cloudflared.exe would fail because this very process was
+// still running from it. Starting the script and returning immediately lets
+// the caller (Apply, then the update command's Action) return right away, so
+// the process exits and releases the binary before the script needs it gone.
+//
+// Because of that, this function can only report whether the script was
+// launched, not whether the update it performs ultimately succeeds. The
+// script cleans up after itself (including deleting itself) once it is done.
 func runWindowsBatch(batchFile string) error {
-	defer os.Remove(batchFile)
 	cmd := exec.Command("cmd", "/C", batchFile)
-	_, err := cmd.Output()
-	// Remove the batch file we created. Don't let this interfere with the error
-	// we report.
-	if err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			return fmt.Errorf("Error during update : %s;", string(exitError.Stderr))
-		}
-	}
-	return err
+	return cmd.Start()
 }

--- a/cmd/cloudflared/updater/workers_update_test.go
+++ b/cmd/cloudflared/updater/workers_update_test.go
@@ -1,0 +1,74 @@
+//go:build !windows
+
+package updater
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWriteBatchFileCRLF guards against a regression of
+// https://github.com/cloudflare/cloudflared/issues/667: cmd.exe's parser is
+// unreliable with GOTOs/labels in a script that has Unix line endings, so the
+// rendered batch file must use CRLF throughout.
+func TestWriteBatchFileCRLF(t *testing.T) {
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "cloudflared.exe")
+	newPath := targetPath + ".new"
+	oldPath := targetPath + ".old"
+
+	require.NoError(t, writeBatchFile(targetPath, newPath, oldPath))
+
+	content, err := os.ReadFile(filepath.Join(dir, batchFileName))
+	require.NoError(t, err)
+
+	// No bare LF: every "\n" must be preceded by "\r".
+	withoutCRLF := strings.ReplaceAll(string(content), "\r\n", "")
+	require.NotContains(t, withoutCRLF, "\n", "batch file must use CRLF line endings, not bare LF")
+	require.NotContains(t, withoutCRLF, "\r", "batch file must not contain a lone CR")
+}
+
+// TestWriteBatchFileContent guards against a regression of
+// https://github.com/cloudflare/cloudflared/issues/667, where the update
+// script reported success even though it silently failed to replace the
+// binary. The script must:
+//   - wait for the service to actually stop (via "net stop", not the
+//     fire-and-forget "sc stop") before touching the binary that the service,
+//     and this very update process, may still have open;
+//   - check each rename for failure instead of unconditionally exiting 0; and
+//   - restore the original binary if the update can't be completed, rather
+//     than leaving the install without an executable.
+func TestWriteBatchFileContent(t *testing.T) {
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "cloudflared.exe")
+	newPath := targetPath + ".new"
+	oldPath := targetPath + ".old"
+
+	require.NoError(t, writeBatchFile(targetPath, newPath, oldPath))
+
+	raw, err := os.ReadFile(filepath.Join(dir, batchFileName))
+	require.NoError(t, err)
+	content := string(raw)
+
+	require.Contains(t, content, "net stop cloudflared")
+	require.NotContains(t, content, "sc stop cloudflared",
+		"sc stop only requests a stop and returns immediately, racing the rename")
+
+	require.Contains(t, content, `rename "`+targetPath+`" cloudflared.exe.old`)
+	require.Contains(t, content, `rename "`+newPath+`" cloudflared.exe`)
+
+	// Every rename must be checked, and a failure after the binary has
+	// already been moved out of the way must restore it.
+	require.Contains(t, content, "if errorlevel 1 goto fail")
+	require.Contains(t, content, "if errorlevel 1 goto restore")
+	require.Contains(t, content, ":restore")
+	require.Contains(t, content, `rename "`+oldPath+`" cloudflared.exe`)
+
+	// The script must clean up after itself instead of relying on the
+	// (about to exit) Go process to remove it.
+	require.Contains(t, content, `del "%~f0"`)
+}


### PR DESCRIPTION
## Summary

Fixes #667, a 4-year-old, maintainer-confirmed bug where `cloudflared.exe update` on Windows can report success (`cloudflared has been updated`, exit code 11) while actually leaving `cloudflared.exe` deleted and the service down, with `cloudflared.exe.old`/`cloudflared.exe.new`/`cfd_update.bat` littered on disk.

Root cause, confirmed by re-reading the generated `cfd_update.bat` against the current code (community member @JonathonFS independently traced the same chain with Process Monitor in the issue thread):

1. **`sc stop` doesn't wait.** It only requests a stop and returns immediately. If the service (or the very `update` process, which is running the same binary) hadn't released the file yet, the following `rename` raced it.
2. **`runWindowsBatch` blocked on the whole script via `cmd.Output()`**, including the trailing `sc start`. That kept the `cloudflared.exe update` process alive for the entire script — but the script's job is to rename *that exact running binary*, and Windows won't complete that rename while something is still waiting on the process. The rename fails right when the tool is depending on it most.
3. **The script always ended with an unconditional `exit /b 0`.** Any rename failure inside the script was swallowed, so the Go side always saw "success" regardless of what actually happened on disk.

Together these produce exactly the reported symptom: `.old`/`.new` left behind, `cloudflared.exe` missing, service down, log says it worked.

## Fix

- Use `net stop` instead of `sc stop` — it blocks until the service has actually stopped.
- Switch `runWindowsBatch` to `cmd.Start()` instead of `cmd.Output()`, so the update process returns (and the CLI framework's `ExitCoder` handling exits it) right after launching the script, instead of holding the binary open for the script's whole run.
- Check the errorlevel after each `rename`; if replacing the binary fails partway through, restore the original from `.old` rather than leaving no executable at all.
- Have the script delete itself (`del "%~f0"`) once done, since the Go side can no longer safely `os.Remove` the batch file after switching away from the blocking call.
- Render the script with CRLF line endings — `cmd.exe`'s parser is unreliable with GOTOs/labels over Unix line endings, which the new error-handling branches now rely on.

## Test plan

- [x] `go test ./cmd/cloudflared/updater/...` — full package suite passes, including two new tests covering the rendered script's line endings and control flow (`net stop` present/`sc stop` absent, checked renames, rollback path, self-cleanup).
- [x] `go build ./...` on the host platform.
- [x] `GOOS=windows GOARCH=amd64 go build ./...` — full `cloudflared` binary cross-compiles cleanly.
- [ ] Not able to exercise the actual Windows service stop/rename/restart sequence end-to-end in this environment (no Windows host available) — would appreciate a maintainer or an affected reporter from #667 validating on a real Windows install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)