### PR TITLE
Fix: Show current version when no update cloudflared | cmd: cloudflared update

### DIFF
--- a/cmd/cloudflared/updater/update.go
+++ b/cmd/cloudflared/updater/update.go
@@ -173,7 +173,7 @@ func Update(c *cli.Context) error {
 	}
 
 	if updateOutcome.noUpdate() {
-		log.Info().Str(LogFieldVersion, updateOutcome.Version).Msg("cloudflared is up to date")
+		log.Info().Str(LogFieldVersion, buildInfo.CloudflaredVersion).Msg("cloudflared is up to date")
 		return nil
 	}
 


### PR DESCRIPTION
This pull request makes a small change to the logging behavior in the updater. The update ensures that the log message for "cloudflared is up to date" always reports the actual running version, rather than the version from the update outcome object.