### PR TITLE
Fix Update log message to use buildInfo version

### DIFF
--- a/cmd/cloudflared/updater/update.go
+++ b/cmd/cloudflared/updater/update.go
@@ -173,7 +173,7 @@ func Update(c *cli.Context) error {
 	}
 
 	if updateOutcome.noUpdate() {
-		log.Info().Str(LogFieldVersion, updateOutcome.Version).Msg("cloudflared is up to date")
+		log.Info().Str(LogFieldVersion, buildInfo.CloudflaredVersion).Msg("cloudflared is up to date")
 		return nil
 	}
 


### PR DESCRIPTION
This pull request makes a minor update to the logging behavior in the `Update` function. The log message for when `cloudflared` is up to date now correctly reports the current running version instead of the version from the update check result.